### PR TITLE
Generalize export-service visual clip detection to use registry

### DIFF
--- a/app/backend/src/lib/export-handler-registry.ts
+++ b/app/backend/src/lib/export-handler-registry.ts
@@ -47,6 +47,10 @@ export class ExportHandlerRegistry {
     return this.clipHandlers.find((h) => h.assetKind === assetKind);
   }
 
+  hasClipHandler(assetKind: string): boolean {
+    return this.clipHandlers.some((h) => h.assetKind === assetKind);
+  }
+
   getOverlayHandlers(): ExportOverlayHandler[] {
     return [...this.overlayHandlers];
   }

--- a/app/backend/src/lib/export-handlers/audio-mix-handler.ts
+++ b/app/backend/src/lib/export-handlers/audio-mix-handler.ts
@@ -12,7 +12,7 @@ export const audioMixHandler: ExportAudioHandler = {
       const asset = ctx.project.assets.find((a) => a.id === clip.assetId);
       const inputIdx = ctx.clipInputIndices.get(clip.id);
       if (inputIdx == null || !asset) continue;
-      if (asset.kind === "video" && asset.hasAudio) {
+      if (asset.hasAudio) {
         audioStreams.push({ inputIdx, clip, asset });
       }
     }

--- a/app/backend/src/routes/exports.test.ts
+++ b/app/backend/src/routes/exports.test.ts
@@ -26,27 +26,31 @@ beforeAll(async () => {
   await mkdir(assetsPath, { recursive: true });
   await writeFile(path.join(assetsPath, "dummy.mp4"), "fake video");
 
-  // Update project with a video clip
+  // Update project with a video clip (sequence via API, assets via direct file write)
   await app.request(`/api/projects/${projectId}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      assets: [
-        { id: "v1", kind: "video", originalPath: "assets/dummy.mp4", durationMs: 5000, hasAudio: false },
-      ],
       sequence: {
         tracks: [
           {
             id: "t1",
-            kind: "video",
             clips: [
-              { id: "c1", assetId: "v1", startMs: 0, durationMs: 5000, inMs: 0, outMs: 5000 },
+              { id: "c1", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 5000, inMs: 0, outMs: 5000 },
             ],
           },
         ],
       },
     }),
   });
+
+  // Write assets directly into project.json (updateProject only handles sequence/settings)
+  const projectJsonPath = path.join(tmpDir, "projects", projectId, "project.json");
+  const projectData = JSON.parse(await Bun.file(projectJsonPath).text());
+  projectData.assets = [
+    { id: "v1", kind: "video", originalPath: "assets/dummy.mp4", durationMs: 5000, hasAudio: false },
+  ];
+  await writeFile(projectJsonPath, JSON.stringify(projectData, null, 2));
 });
 
 afterAll(async () => {

--- a/app/backend/src/services/export-service.test.ts
+++ b/app/backend/src/services/export-service.test.ts
@@ -273,12 +273,12 @@ describe("buildExportArgs", () => {
     expect(args).toContain("bt709");
   });
 
-  test("throws for missing asset", () => {
+  test("throws when no assets match any clip handler", () => {
     const project = makeProject({
-      assets: [], // no assets
+      assets: [], // no assets — clips are skipped by registry lookup
     });
     expect(() => buildExportArgs(project, "/assets", "/out.mp4")).toThrow(
-      "Asset not found",
+      "No video clips to export",
     );
   });
 

--- a/app/backend/src/services/export-service.ts
+++ b/app/backend/src/services/export-service.ts
@@ -91,11 +91,13 @@ export function buildExportArgs(
   // Project duration limit
   const projectDurationMs = project.settings?.durationMs;
 
-  // Collect all visual clips (video/image) from all tracks, with track index
+  // Collect all visual clips from all tracks, with track index.
+  // A clip is "visual" if a clip handler is registered for its asset kind.
   const allVisualClips: { clip: Clip; trackIndex: number }[] = [];
   project.sequence.tracks.forEach((track, trackIndex) => {
     for (const clip of track.clips) {
-      if (clip.clipKind === "video" || clip.clipKind === "image") {
+      const asset = project.assets.find((a) => a.id === clip.assetId);
+      if (asset && exportHandlerRegistry.hasClipHandler(asset.kind)) {
         allVisualClips.push({ clip, trackIndex });
       }
     }
@@ -365,7 +367,10 @@ export async function startExport(
 
   // Validate - check for visual clips across all tracks
   const visualClips = project.sequence.tracks.flatMap((t) =>
-    t.clips.filter((c) => c.clipKind === "video" || c.clipKind === "image"),
+    t.clips.filter((c) => {
+      const asset = project.assets.find((a) => a.id === c.assetId);
+      return asset != null && exportHandlerRegistry.hasClipHandler(asset.kind);
+    }),
   );
   if (visualClips.length === 0) {
     throw new Error("No video clips to export");


### PR DESCRIPTION
## Summary
- `export-service.ts` の `clipKind === "video" || clipKind === "image"` ハードコードをレジストリベースの判定に置換
- `ExportHandlerRegistry.hasClipHandler(assetKind)` メソッドを追加
- `audio-mix-handler.ts` の `asset.kind === "video"` チェックを `asset.hasAudio` に一般化
- テストデータを修正し、assets が正しくセットアップされるように

## Motivation
新しいビジュアルクリップ種別（p5.js、CSSアニメーション等）を追加する際に `export-service.ts` を変更せずに済むようにする。Phase 0 (Chromium Renderer & p5.js) の前提条件。

Closes #58

## Test plan
- [x] 全313テストパス（`bun run test`）
- [x] エクスポートリグレッションテスト変更なし
- [x] スナップショットテスト変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)