### PR TITLE
Add optional metadata fields to Track type

### DIFF
--- a/app/shared/src/types/project.ts
+++ b/app/shared/src/types/project.ts
@@ -24,6 +24,10 @@ export type Sequence = {
 export type Track = {
   id: string;
   clips: Clip[];
+  name?: string;
+  color?: string;
+  locked?: boolean;
+  muted?: boolean;
 };
 
 export type ClipText = {


### PR DESCRIPTION
## Summary
- `Track` 型に `name?`, `color?`, `locked?`, `muted?` フィールドを追加
- 既存プロジェクトとの後方互換性を維持（すべて optional）
- Phase 1 #9 (Track Lock & Mute), #10 (Track Naming & Color) の前提条件

Closes #64

## Test plan
- [x] All tests pass (`bun run test`)
- [x] Type check passes
- [x] No behavioral changes — data model extension only

🤖 Generated with [Claude Code](https://claude.com/claude-code)