### PR TITLE
Add web-render pipeline step for HTML-to-MP4 conversion

### DIFF
--- a/app/backend/src/pipeline/steps/index.ts
+++ b/app/backend/src/pipeline/steps/index.ts
@@ -3,8 +3,10 @@ import { probeStep } from "./probe";
 import { thumbnailStep } from "./thumbnail";
 import { proxyStep } from "./proxy";
 import { imageConvertStep } from "./image-convert";
+import { webRenderStep } from "./web-render";
 
 registerStep(probeStep);
 registerStep(thumbnailStep);
 registerStep(proxyStep);
 registerStep(imageConvertStep);
+registerStep(webRenderStep);

--- a/app/backend/src/pipeline/steps/web-render.test.ts
+++ b/app/backend/src/pipeline/steps/web-render.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { webRenderStep } from "./web-render";
+import type { PipelineContext } from "../types";
+import type { Asset } from "@video/shared";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_HTML = `<!DOCTYPE html>
+<html>
+<body style="margin:0">
+<canvas id="c" width="320" height="240"></canvas>
+<script>
+const ctx = document.getElementById('c').getContext('2d');
+ctx.fillStyle = 'red';
+ctx.fillRect(0, 0, 320, 240);
+window.__ready = true;
+window.__renderFrame = function(i) {
+  ctx.fillStyle = i % 2 === 0 ? 'red' : 'blue';
+  ctx.fillRect(0, 0, 320, 240);
+};
+</script>
+</body>
+</html>`;
+
+let tmpProjectDir: string;
+
+afterAll(async () => {
+  if (tmpProjectDir) {
+    await rm(tmpProjectDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+describe("webRenderStep", () => {
+  test("canHandle returns true only when webRenderHtml is in shared", () => {
+    const sharedWith = new Map<string, unknown>([["webRenderHtml", "<html/>"]]);
+    const sharedWithout = new Map<string, unknown>();
+
+    const baseCtx = {
+      asset: { id: "a", kind: "video", originalPath: "" } as Asset,
+      projectDir: "/tmp",
+      projectId: "p1",
+      reportProgress: () => {},
+    };
+
+    expect(webRenderStep.canHandle({ ...baseCtx, shared: sharedWith })).toBe(
+      true,
+    );
+    expect(
+      webRenderStep.canHandle({ ...baseCtx, shared: sharedWithout }),
+    ).toBe(false);
+  });
+
+  test(
+    "renders HTML canvas to MP4 with correct resolution and frame count",
+    async () => {
+      tmpProjectDir = await mkdtemp(join(tmpdir(), "web-render-test-"));
+
+      const asset: Asset = {
+        id: "test-asset",
+        kind: "video",
+        originalPath: "",
+      };
+
+      const shared = new Map<string, unknown>();
+      shared.set("webRenderHtml", TEST_HTML);
+      shared.set("webRenderSettings", {
+        width: 320,
+        height: 240,
+        fps: 10,
+        durationMs: 1000,
+      });
+
+      const progressValues: number[] = [];
+      const ctx: PipelineContext = {
+        asset,
+        projectDir: tmpProjectDir,
+        projectId: "test-project",
+        shared,
+        reportProgress: (f) => progressValues.push(f),
+      };
+
+      await webRenderStep.execute(ctx);
+
+      // Verify asset path was updated
+      expect(ctx.asset.originalPath).toBe("assets/test-asset-rendered.mp4");
+
+      // Verify the MP4 file exists
+      const outputPath = join(tmpProjectDir, ctx.asset.originalPath);
+      const fileStat = await stat(outputPath);
+      expect(fileStat.size).toBeGreaterThan(0);
+
+      // Use ffprobe to verify resolution and frame count
+      const probeProc = Bun.spawn(
+        [
+          "ffprobe",
+          "-v",
+          "quiet",
+          "-print_format",
+          "json",
+          "-show_streams",
+          "-show_format",
+          outputPath,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+
+      const probeStdout = await new Response(probeProc.stdout).text();
+      const probeExit = await probeProc.exited;
+      expect(probeExit).toBe(0);
+
+      const probeData = JSON.parse(probeStdout);
+      const videoStream = probeData.streams?.find(
+        (s: { codec_type: string }) => s.codec_type === "video",
+      );
+
+      expect(videoStream).toBeDefined();
+      expect(videoStream.width).toBe(320);
+      expect(videoStream.height).toBe(240);
+
+      // Verify approximate frame count (10 fps * 1s = 10 frames)
+      const nbFrames = parseInt(videoStream.nb_frames, 10);
+      expect(nbFrames).toBeGreaterThanOrEqual(9);
+      expect(nbFrames).toBeLessThanOrEqual(11);
+
+      // Verify progress was reported
+      expect(progressValues.length).toBeGreaterThan(0);
+      expect(progressValues[progressValues.length - 1]).toBe(1.0);
+    },
+    30_000,
+  );
+});

--- a/app/backend/src/pipeline/steps/web-render.ts
+++ b/app/backend/src/pipeline/steps/web-render.ts
@@ -1,0 +1,141 @@
+import type { PipelineStep } from "../types";
+import { chromiumTool } from "../tools/chromium";
+import { join } from "node:path";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+export type WebRenderSettings = {
+  width: number;
+  height: number;
+  fps: number;
+  durationMs: number;
+};
+
+export const webRenderStep: PipelineStep = {
+  name: "web-render",
+
+  canHandle: (ctx) => ctx.shared.has("webRenderHtml"),
+
+  async execute(ctx) {
+    const html = ctx.shared.get("webRenderHtml") as string;
+    const settings = ctx.shared.get("webRenderSettings") as WebRenderSettings;
+
+    if (!html || !settings) {
+      throw new Error(
+        "web-render requires webRenderHtml and webRenderSettings in shared context",
+      );
+    }
+
+    const { width, height, fps, durationMs } = settings;
+    const totalFrames = Math.ceil((durationMs / 1000) * fps);
+
+    // 1. Write HTML to temp file
+    const tmpHtmlPath = join(
+      tmpdir(),
+      `web-render-${ctx.asset.id}-${Date.now()}.html`,
+    );
+    await writeFile(tmpHtmlPath, html);
+
+    // 2. Output path in assets dir
+    const outputDir = join(ctx.projectDir, "assets");
+    await mkdir(outputDir, { recursive: true });
+    const outputPath = join(outputDir, `${ctx.asset.id}-rendered.mp4`);
+
+    // 3. Launch Chromium and navigate
+    const session = await chromiumTool.launch({ width, height });
+
+    try {
+      await session.navigate(`file://${tmpHtmlPath}`);
+
+      // Wait for page to be ready (the page can set window.__ready = true)
+      // Poll with timeout
+      const maxWaitMs = 10_000;
+      const pollInterval = 100;
+      let waited = 0;
+      while (waited < maxWaitMs) {
+        const ready = await session.evaluate<boolean>(
+          "typeof window.__ready !== 'undefined' ? window.__ready : true",
+        );
+        if (ready) break;
+        await new Promise((r) => setTimeout(r, pollInterval));
+        waited += pollInterval;
+      }
+
+      // 4. Spawn ffmpeg to receive PNG frames on stdin (image2pipe)
+      const ffmpegArgs = [
+        "-y",
+        "-f",
+        "image2pipe",
+        "-framerate",
+        String(fps),
+        "-i",
+        "pipe:0",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-preset",
+        "fast",
+        "-crf",
+        "23",
+        "-r",
+        String(fps),
+        "-movflags",
+        "+faststart",
+        outputPath,
+      ];
+
+      const ffmpegProc = Bun.spawn(["ffmpeg", ...ffmpegArgs], {
+        stdin: "pipe",
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+
+      // 5. Capture frames and pipe to ffmpeg
+      const renderExpression = `
+        (function() {
+          if (typeof window.__renderFrame === 'function') {
+            window.__renderFrame(__frameIndex);
+          }
+          // Find the first canvas element and return its data URL
+          const canvas = document.querySelector('canvas');
+          if (!canvas) throw new Error('No canvas element found');
+          return canvas.toDataURL('image/png');
+        })()
+      `;
+
+      const frames = session.captureFrames({
+        totalFrames,
+        fps,
+        renderExpression,
+        onProgress: (fraction) => ctx.reportProgress(fraction * 0.9), // Reserve 10% for ffmpeg finalization
+      });
+
+      const writer = ffmpegProc.stdin!;
+      for await (const pngBuffer of frames) {
+        writer.write(pngBuffer);
+      }
+      writer.end();
+
+      // 6. Wait for ffmpeg to finish
+      const exitCode = await ffmpegProc.exited;
+      if (exitCode !== 0) {
+        const stderr = ffmpegProc.stderr
+          ? await new Response(ffmpegProc.stderr).text()
+          : "";
+        throw new Error(
+          `web-render ffmpeg failed (exit ${exitCode}): ${stderr}`,
+        );
+      }
+
+      ctx.reportProgress(1.0);
+
+      // 7. Update asset's originalPath to point to the rendered MP4
+      ctx.asset.originalPath = `assets/${ctx.asset.id}-rendered.mp4`;
+    } finally {
+      await session.close();
+      // Clean up temp HTML file
+      await rm(tmpHtmlPath, { force: true }).catch(() => {});
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- HTML コンテンツを Chromium でフレームキャプチャし ffmpeg で MP4 にエンコードする汎用パイプラインステップ
- `webRenderHtml` と `webRenderSettings` を shared context 経由で受け取る（コンテンツ非依存）
- `captureFrames` → ffmpeg `image2pipe` のストリーミングでメモリ効率的
- `window.__ready` ポーリング、`window.__renderFrame` コールバック対応

Closes #57

## Test plan
- [x] All 318 tests pass
- [x] Integration test: canvas HTML → MP4 → ffprobe で解像度・フレーム数検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)