### PR TITLE
Register p5.js asset detector and export handler

### DIFF
--- a/app/backend/src/lib/asset-detectors/p5js-detector.ts
+++ b/app/backend/src/lib/asset-detectors/p5js-detector.ts
@@ -1,0 +1,15 @@
+import type { AssetDetector, AssetDetectionContext } from "../asset-detector-registry";
+
+/**
+ * Detect p5.js sketch files by the `.p5.js` filename suffix.
+ * Higher priority than extension-detector so `.p5.js` files are not
+ * misidentified as generic JS files.
+ */
+export const p5jsDetector: AssetDetector = {
+  name: "p5js",
+  priority: 10,
+  detect: (ctx: AssetDetectionContext): string | null => {
+    if (ctx.filename.endsWith(".p5.js")) return "p5js";
+    return null;
+  },
+};

--- a/app/backend/src/lib/builtin-plugin.ts
+++ b/app/backend/src/lib/builtin-plugin.ts
@@ -4,6 +4,7 @@ import type { ExportHandlerRegistry } from "./export-handler-registry";
 import type { CompositeStrategyRegistry } from "./composite-strategy-registry";
 import type { TransitionExportRegistry } from "./transition-export-registry";
 import { extensionDetector } from "./asset-detectors/extension-detector";
+import { p5jsDetector } from "./asset-detectors/p5js-detector";
 import { videoClipHandler } from "./export-handlers/video-clip-handler";
 import { imageClipHandler } from "./export-handlers/image-clip-handler";
 import { textOverlayHandler } from "./export-handlers/text-overlay-handler";
@@ -43,11 +44,14 @@ export const builtinPlugin: BackendPlugin = {
 
   registerAssetDetectors(registry: AssetDetectorRegistry) {
     registry.register(extensionDetector);
+    registry.register(p5jsDetector);
   },
 
   registerExportHandlers(registry: ExportHandlerRegistry) {
     registry.registerClipHandler(videoClipHandler);
     registry.registerClipHandler(imageClipHandler);
+    // p5js assets are pre-rendered to MP4, so reuse the video clip handler
+    registry.registerClipHandler({ assetKind: "p5js", buildInput: videoClipHandler.buildInput });
     registry.registerOverlayHandler(textOverlayHandler);
     registry.registerAudioHandler(audioMixHandler);
   },


### PR DESCRIPTION
## Summary
- `.p5.js` ファイルを検出する p5js-detector を追加（priority 10）
- p5js export clip handler を videoClipHandler.buildInput の再利用で登録

Closes #60

## Test plan
- [x] All 328 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)