### PR TITLE
Register p5.js clip kind, asset kind, and editor in frontend plugin

### DIFF
--- a/app/frontend/src/components/AssetPanel.tsx
+++ b/app/frontend/src/components/AssetPanel.tsx
@@ -68,7 +68,7 @@ export function AssetPanel({ project, onAddToTimeline }: Props) {
         ref={fileInputRef}
         type="file"
         multiple
-        accept="video/*,image/*,audio/*,.heic"
+        accept="video/*,image/*,audio/*,.heic,.p5.js"
         style={{ display: "none" }}
         onChange={handleFileSelect}
       />

--- a/app/frontend/src/components/editors/P5jsEditor.tsx
+++ b/app/frontend/src/components/editors/P5jsEditor.tsx
@@ -1,0 +1,29 @@
+import { theme } from "../../theme";
+import type { InspectorEditorContext } from "../../lib/inspector-editor-registry";
+
+export function P5jsEditor({ asset }: InspectorEditorContext) {
+  if (!asset) return null;
+
+  return (
+    <div style={{ marginTop: "8px" }}>
+      <label style={{ color: theme.textMuted, display: "block", marginBottom: "4px" }}>
+        p5.js Sketch
+      </label>
+      <div style={{
+        fontFamily: "monospace",
+        fontSize: "11px",
+        color: theme.text,
+        backgroundColor: theme.bgPanel,
+        border: `1px solid ${theme.border}`,
+        borderRadius: "4px",
+        padding: "8px",
+        maxHeight: "200px",
+        overflow: "auto",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+      }}>
+        {asset.originalPath}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/renderers/VideoClipRenderer.tsx
+++ b/app/frontend/src/components/renderers/VideoClipRenderer.tsx
@@ -5,7 +5,7 @@ import { compositeStrategyRegistry } from "../../lib/composite-strategy-registry
 import type { Asset } from "@video/shared";
 
 function getVideoMediaUrl(asset: Asset, projectId: string): string {
-  if (asset.kind === "video" && asset.proxyPath) {
+  if ((asset.kind === "video" || asset.kind === "p5js") && asset.proxyPath) {
     const filename = asset.proxyPath.split("/").pop();
     return `/media/projects/${projectId}/proxies/${filename}`;
   }
@@ -156,5 +156,17 @@ export const videoClipRenderer: PreviewLayerRenderer = {
   id: "video-clip",
   zOrder: 0,
   findActiveContent: findActiveVideoClips,
+  Component: VideoClipComponent,
+};
+
+function findActiveP5jsClips(ctx: PreviewRenderContext): ActiveClip[] | null {
+  const clips = findAllActiveClips(ctx.project, ctx.currentTimeMs, "p5js", "p5js");
+  return clips.length > 0 ? clips : null;
+}
+
+export const p5jsClipRenderer: PreviewLayerRenderer = {
+  id: "p5js-clip",
+  zOrder: 0,
+  findActiveContent: findActiveP5jsClips,
   Component: VideoClipComponent,
 };

--- a/app/frontend/src/lib/builtin-plugin.ts
+++ b/app/frontend/src/lib/builtin-plugin.ts
@@ -13,7 +13,8 @@ import { TransformEditor } from "../components/editors/TransformEditor";
 import { AudioVolumeEditor } from "../components/editors/AudioVolumeEditor";
 import { BlendModeEditor } from "../components/editors/BlendModeEditor";
 import { TransitionEditor } from "../components/editors/TransitionEditor";
-import { videoClipRenderer } from "../components/renderers/VideoClipRenderer";
+import { P5jsEditor } from "../components/editors/P5jsEditor";
+import { videoClipRenderer, p5jsClipRenderer } from "../components/renderers/VideoClipRenderer";
 import { imageClipRenderer } from "../components/renderers/ImageClipRenderer";
 import { textOverlayRenderer } from "../components/renderers/TextOverlayRenderer";
 import type { ActiveClip, TickContext } from "./preview-renderer-registry";
@@ -77,6 +78,14 @@ export const builtinPlugin: FrontendPlugin = {
       hasSourceTrim: false,
       hasAsset: false,
     });
+    registry.register({
+      kind: "p5js",
+      label: "p5.js",
+      clipColor: "#ed225d",
+      clipSelectedColor: "#ff4081",
+      hasSourceTrim: false,
+      hasAsset: true,
+    });
   },
 
   registerAssetKinds(registry: AssetKindRegistry) {
@@ -104,6 +113,15 @@ export const builtinPlugin: FrontendPlugin = {
       mimePatterns: ["audio/*"],
       defaultTrackKind: "audio",
       hasDuration: true,
+    });
+    registry.register({
+      kind: "p5js",
+      label: "p5.js",
+      extensions: [".p5.js"],
+      mimePatterns: [],
+      defaultTrackKind: "video",
+      hasDuration: false,
+      defaultDurationMs: 5000,
     });
   },
 
@@ -150,15 +168,50 @@ export const builtinPlugin: FrontendPlugin = {
       canHandle: (ctx) => ctx.clipKind === "audio",
       Component: AudioVolumeEditor,
     });
+    registry.register({
+      id: "p5js",
+      label: "Sketch",
+      order: 15,
+      canHandle: (ctx) => ctx.clipKind === "p5js",
+      Component: P5jsEditor,
+    });
   },
 
   registerPreviewRenderers(registry: PreviewRendererRegistry) {
     registry.register(videoClipRenderer);
+    registry.register(p5jsClipRenderer);
     registry.register(imageClipRenderer);
     registry.register(textOverlayRenderer);
 
     registry.registerTickStrategy({
       assetKind: "video",
+      tick: (clip: ActiveClip, deltaMs: number, tickCtx: TickContext): number | null => {
+        const { currentTimeMs, videoRef, lastClipId, videoEnded, resetVideoEnded } = tickCtx;
+        const clipEndMs = clip.clip.startMs + clip.clip.durationMs;
+        const videoReady = clip.clip.id === lastClipId;
+
+        if (!videoRef) {
+          return null;
+        } else if (!videoReady) {
+          return Math.min(currentTimeMs + deltaMs, clipEndMs);
+        } else if (videoRef.ended || videoEnded) {
+          resetVideoEnded();
+          return Math.min(currentTimeMs + deltaMs, clipEndMs);
+        } else if (videoRef.readyState >= 2 && !videoRef.paused) {
+          const videoTimeMs = videoRef.currentTime * 1000;
+          const expectedVideoTime = clip.clip.inMs + (currentTimeMs - clip.clip.startMs);
+          if (Math.abs(videoTimeMs - expectedVideoTime) > 500) {
+            return Math.min(currentTimeMs + deltaMs, clipEndMs);
+          }
+          const timelineMs = clip.clip.startMs + (videoTimeMs - clip.clip.inMs);
+          return Math.max(clip.clip.startMs, Math.min(timelineMs, clipEndMs));
+        }
+        return null;
+      },
+    });
+
+    registry.registerTickStrategy({
+      assetKind: "p5js",
       tick: (clip: ActiveClip, deltaMs: number, tickCtx: TickContext): number | null => {
         const { currentTimeMs, videoRef, lastClipId, videoEnded, resetVideoEnded } = tickCtx;
         const clipEndMs = clip.clip.startMs + clip.clip.durationMs;

--- a/app/frontend/src/lib/clip-kind-registry.test.ts
+++ b/app/frontend/src/lib/clip-kind-registry.test.ts
@@ -3,14 +3,15 @@ import { ClipKindRegistry } from "./clip-kind-registry";
 import { clipKindRegistry } from "./clip-kind-registry";
 
 describe("ClipKindRegistry", () => {
-  test("builtin plugin registers 4 default kinds", () => {
+  test("builtin plugin registers 5 default kinds", () => {
     const all = clipKindRegistry.all();
-    expect(all.length).toBe(4);
+    expect(all.length).toBe(5);
     const kinds = all.map((d) => d.kind);
     expect(kinds).toContain("video");
     expect(kinds).toContain("audio");
     expect(kinds).toContain("image");
     expect(kinds).toContain("title");
+    expect(kinds).toContain("p5js");
   });
 
   test("get returns descriptor for registered kind", () => {


### PR DESCRIPTION
## Summary
- p5.js clip kind 登録（ブランドカラー #ed225d）
- p5.js asset kind 登録（.p5.js 拡張子）
- P5jsEditor コンポーネント（スケッチ情報表示）
- VideoClipRenderer を p5js でも使用可能に
- AssetPanel の accept に .p5.js を追加

Closes #61

## Test plan
- [x] All 328 tests pass
- [x] clip-kind-registry テスト更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)