### PR TITLE
Fix web-render step robustness issues

### DIFF
--- a/app/backend/src/pipeline/steps/web-render.ts
+++ b/app/backend/src/pipeline/steps/web-render.ts
@@ -34,107 +34,121 @@ export const webRenderStep: PipelineStep = {
       tmpdir(),
       `web-render-${ctx.asset.id}-${Date.now()}.html`,
     );
-    await writeFile(tmpHtmlPath, html);
-
-    // 2. Output path in assets dir
-    const outputDir = join(ctx.projectDir, "assets");
-    await mkdir(outputDir, { recursive: true });
-    const outputPath = join(outputDir, `${ctx.asset.id}-rendered.mp4`);
-
-    // 3. Launch Chromium and navigate
-    const session = await chromiumTool.launch({ width, height });
 
     try {
-      await session.navigate(`file://${tmpHtmlPath}`);
+      await writeFile(tmpHtmlPath, html);
 
-      // Wait for page to be ready (the page can set window.__ready = true)
-      // Poll with timeout
-      const maxWaitMs = 10_000;
-      const pollInterval = 100;
-      let waited = 0;
-      while (waited < maxWaitMs) {
-        const ready = await session.evaluate<boolean>(
-          "typeof window.__ready !== 'undefined' ? window.__ready : true",
-        );
-        if (ready) break;
-        await new Promise((r) => setTimeout(r, pollInterval));
-        waited += pollInterval;
-      }
+      // 2. Output path in assets dir
+      const outputDir = join(ctx.projectDir, "assets");
+      await mkdir(outputDir, { recursive: true });
+      const outputPath = join(outputDir, `${ctx.asset.id}-rendered.mp4`);
 
-      // 4. Spawn ffmpeg to receive PNG frames on stdin (image2pipe)
-      const ffmpegArgs = [
-        "-y",
-        "-f",
-        "image2pipe",
-        "-framerate",
-        String(fps),
-        "-i",
-        "pipe:0",
-        "-c:v",
-        "libx264",
-        "-pix_fmt",
-        "yuv420p",
-        "-preset",
-        "fast",
-        "-crf",
-        "23",
-        "-r",
-        String(fps),
-        "-movflags",
-        "+faststart",
-        outputPath,
-      ];
+      // 3. Launch Chromium and navigate
+      const session = await chromiumTool.launch({ width, height });
 
-      const ffmpegProc = Bun.spawn(["ffmpeg", ...ffmpegArgs], {
-        stdin: "pipe",
-        stdout: "ignore",
-        stderr: "pipe",
-      });
+      try {
+        await session.navigate(`file://${tmpHtmlPath}`);
 
-      // 5. Capture frames and pipe to ffmpeg
-      const renderExpression = `
-        (function() {
-          if (typeof window.__renderFrame === 'function') {
-            window.__renderFrame(__frameIndex);
+        // Wait for page to be ready (the page can set window.__ready = true)
+        const maxWaitMs = 10_000;
+        const pollInterval = 100;
+        let waited = 0;
+        while (waited < maxWaitMs) {
+          const ready = await session.evaluate<boolean>(
+            "typeof window.__ready !== 'undefined' ? window.__ready : true",
+          );
+          if (ready) break;
+          await new Promise((r) => setTimeout(r, pollInterval));
+          waited += pollInterval;
+        }
+
+        // 4. Spawn ffmpeg to receive PNG frames on stdin (image2pipe)
+        const ffmpegArgs = [
+          "-y",
+          "-f",
+          "image2pipe",
+          "-framerate",
+          String(fps),
+          "-i",
+          "pipe:0",
+          "-c:v",
+          "libx264",
+          "-pix_fmt",
+          "yuv420p",
+          "-preset",
+          "fast",
+          "-crf",
+          "23",
+          "-r",
+          String(fps),
+          "-movflags",
+          "+faststart",
+          outputPath,
+        ];
+
+        const ffmpegProc = Bun.spawn(["ffmpeg", ...ffmpegArgs], {
+          stdin: "pipe",
+          stdout: "ignore",
+          stderr: "pipe",
+        });
+
+        // Start draining stderr concurrently to prevent deadlock
+        const stderrPromise = ffmpegProc.stderr
+          ? new Response(ffmpegProc.stderr).text()
+          : Promise.resolve("");
+
+        try {
+          // 5. Capture frames and pipe to ffmpeg
+          const renderExpression = `
+            (function() {
+              if (typeof window.__renderFrame === 'function') {
+                window.__renderFrame(__frameIndex);
+              }
+              // Find the first canvas element and return its data URL
+              const canvas = document.querySelector('canvas');
+              if (!canvas) throw new Error('No canvas element found');
+              return canvas.toDataURL('image/png');
+            })()
+          `;
+
+          const frames = session.captureFrames({
+            totalFrames,
+            fps,
+            renderExpression,
+            onProgress: (fraction) => ctx.reportProgress(fraction * 0.9),
+          });
+
+          const writer = ffmpegProc.stdin!;
+          for await (const pngBuffer of frames) {
+            writer.write(pngBuffer);
           }
-          // Find the first canvas element and return its data URL
-          const canvas = document.querySelector('canvas');
-          if (!canvas) throw new Error('No canvas element found');
-          return canvas.toDataURL('image/png');
-        })()
-      `;
+          writer.end();
+        } catch (err) {
+          // Kill ffmpeg if frame capture fails to prevent hanging
+          try { ffmpegProc.kill(); } catch { /* ignore */ }
+          throw err;
+        }
 
-      const frames = session.captureFrames({
-        totalFrames,
-        fps,
-        renderExpression,
-        onProgress: (fraction) => ctx.reportProgress(fraction * 0.9), // Reserve 10% for ffmpeg finalization
-      });
+        // 6. Wait for ffmpeg to finish
+        const [exitCode, stderrText] = await Promise.all([
+          ffmpegProc.exited,
+          stderrPromise,
+        ]);
+        if (exitCode !== 0) {
+          throw new Error(
+            `web-render ffmpeg failed (exit ${exitCode}): ${stderrText}`,
+          );
+        }
 
-      const writer = ffmpegProc.stdin!;
-      for await (const pngBuffer of frames) {
-        writer.write(pngBuffer);
+        ctx.reportProgress(1.0);
+
+        // 7. Update asset's originalPath to point to the rendered MP4
+        ctx.asset.originalPath = `assets/${ctx.asset.id}-rendered.mp4`;
+      } finally {
+        await session.close();
       }
-      writer.end();
-
-      // 6. Wait for ffmpeg to finish
-      const exitCode = await ffmpegProc.exited;
-      if (exitCode !== 0) {
-        const stderr = ffmpegProc.stderr
-          ? await new Response(ffmpegProc.stderr).text()
-          : "";
-        throw new Error(
-          `web-render ffmpeg failed (exit ${exitCode}): ${stderr}`,
-        );
-      }
-
-      ctx.reportProgress(1.0);
-
-      // 7. Update asset's originalPath to point to the rendered MP4
-      ctx.asset.originalPath = `assets/${ctx.asset.id}-rendered.mp4`;
     } finally {
-      await session.close();
-      // Clean up temp HTML file
+      // Clean up temp HTML file in all paths (including Chromium launch failure)
       await rm(tmpHtmlPath, { force: true }).catch(() => {});
     }
   },


### PR DESCRIPTION
## Summary
PR #71 のレビューで指摘されたロバストネス問題を修正:
- ffmpeg stderr を並行ドレインしてパイプバッファのデッドロックを防止
- フレームキャプチャ失敗時に ffmpeg プロセスを kill（ハング防止）
- tmpHtmlPath のクリーンアップを外側の finally に移動（Chromium launch 失敗時もカバー）

## Test plan
- [x] All 329 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)