### PR TITLE
Add missing regression tests for HIGH-risk coverage gaps

### DIFF
--- a/app/backend/src/lib/asset-detector-registry.test.ts
+++ b/app/backend/src/lib/asset-detector-registry.test.ts
@@ -21,6 +21,33 @@ describe("AssetDetectorRegistry", () => {
     ).toBe("audio");
   });
 
+  describe("p5js detector", () => {
+    test("detects .p5.js files as p5js", () => {
+      expect(
+        assetDetectorRegistry.detect({ filename: "sketch.p5.js", extension: ".js" }),
+      ).toBe("p5js");
+    });
+
+    test("does not detect generic .js files", () => {
+      expect(
+        assetDetectorRegistry.detect({ filename: "script.js", extension: ".js" }),
+      ).not.toBe("p5js");
+    });
+
+    test("does not detect .p5.js.bak files", () => {
+      expect(
+        assetDetectorRegistry.detect({ filename: "sketch.p5.js.bak", extension: ".bak" }),
+      ).not.toBe("p5js");
+    });
+
+    test("p5js has higher priority than extension-detector for .p5.js files", () => {
+      // Verify that test.p5.js is detected as p5js (not as some other kind via extension-detector)
+      expect(
+        assetDetectorRegistry.detect({ filename: "test.p5.js", extension: ".js" }),
+      ).toBe("p5js");
+    });
+  });
+
   describe("isolated instance", () => {
     let registry: AssetDetectorRegistry;
 

--- a/app/backend/src/pipeline/p5js-pipeline.test.ts
+++ b/app/backend/src/pipeline/p5js-pipeline.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { p5jsPrepareStep } from "./steps/p5js-prepare";
+import { webRenderStep } from "./steps/web-render";
+import { ffmpegTool } from "./tools";
+import type { PipelineContext } from "./types";
+import type { Asset } from "@video/shared";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SKETCH_CODE = `function setup() {
+  createCanvas(160, 90);
+}
+function draw() {
+  background(237, 34, 93);
+  fill(255);
+  rect(10, 10, frameCount * 5, 30);
+}`;
+
+let tmpProjectDir: string;
+
+afterAll(async () => {
+  if (tmpProjectDir) {
+    await rm(tmpProjectDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+describe("p5js full pipeline", () => {
+  test(
+    "sketch -> HTML -> Chromium -> ffmpeg -> MP4",
+    async () => {
+      tmpProjectDir = await mkdtemp(join(tmpdir(), "p5js-pipeline-test-"));
+      await writeFile(join(tmpProjectDir, "sketch.p5.js"), SKETCH_CODE);
+
+      const asset: Asset = {
+        id: "p5js-test",
+        kind: "p5js",
+        originalPath: "sketch.p5.js",
+        durationMs: 2000,
+      };
+
+      const shared = new Map<string, unknown>([
+        ["canvasWidth", 160],
+        ["canvasHeight", 90],
+        ["fps", 10],
+        ["durationMs", 2000],
+      ]);
+
+      const ctx: PipelineContext = {
+        asset,
+        projectDir: tmpProjectDir,
+        projectId: "p5js-e2e",
+        shared,
+        reportProgress: () => {},
+      };
+
+      // Step 1: p5js-prepare
+      expect(p5jsPrepareStep.canHandle(ctx)).toBe(true);
+      await p5jsPrepareStep.execute(ctx);
+
+      expect(shared.has("webRenderHtml")).toBe(true);
+      expect(shared.has("webRenderSettings")).toBe(true);
+
+      const html = shared.get("webRenderHtml") as string;
+      expect(html).toContain("createCanvas(160, 90)");
+      expect(html).toContain("background(237, 34, 93)");
+
+      // Step 2: web-render (Chromium + ffmpeg)
+      expect(webRenderStep.canHandle(ctx)).toBe(true);
+      await webRenderStep.execute(ctx);
+
+      // Verify the rendered MP4 exists
+      const outputPath = join(tmpProjectDir, ctx.asset.originalPath);
+      const probeResult = await ffmpegTool.probe(outputPath);
+
+      expect(probeResult.width).toBe(160);
+      expect(probeResult.height).toBe(90);
+      expect(probeResult.codec).toBeTruthy();
+    },
+    60_000,
+  );
+});

--- a/app/frontend/src/lib/asset-kind-registry.test.ts
+++ b/app/frontend/src/lib/asset-kind-registry.test.ts
@@ -32,6 +32,12 @@ describe("AssetKindRegistry", () => {
     expect(assetKindRegistry.detectByExtension(".JPG")?.kind).toBe("image");
   });
 
+  test("p5js kind is registered", () => {
+    const desc = assetKindRegistry.get("p5js");
+    expect(desc).toBeDefined();
+    expect(desc!.extensions).toContain(".p5.js");
+  });
+
   test("detectByExtension returns undefined for unknown extension", () => {
     expect(assetKindRegistry.detectByExtension(".xyz")).toBeUndefined();
     expect(assetKindRegistry.detectByExtension(".doc")).toBeUndefined();

--- a/app/frontend/src/lib/preview-renderer-registry.test.ts
+++ b/app/frontend/src/lib/preview-renderer-registry.test.ts
@@ -16,6 +16,17 @@ describe("PreviewRendererRegistry", () => {
     expect(previewRendererRegistry.getTickStrategy("image")).toBeDefined();
   });
 
+  test("p5js tick strategy is registered", () => {
+    expect(previewRendererRegistry.getTickStrategy("p5js")).toBeDefined();
+  });
+
+  test("p5js renderer is registered with findActiveContent", () => {
+    const all = previewRendererRegistry.all();
+    const p5jsRenderer = all.find((r) => r.id === "p5js-clip");
+    expect(p5jsRenderer).toBeDefined();
+    expect(p5jsRenderer!.findActiveContent).toBeDefined();
+  });
+
   describe("isolated instance", () => {
     let registry: PreviewRendererRegistry;
 

--- a/app/frontend/src/lib/transition-preview-registry.test.ts
+++ b/app/frontend/src/lib/transition-preview-registry.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect } from "bun:test";
+import { transitionPreviewRegistry } from "./transition-preview-registry";
+import { computeTransitionStyle } from "./preview-renderer-registry";
+import type { Clip, Project } from "@video/shared";
+
+describe("TransitionPreviewRegistry", () => {
+  test("all 7 transitions are registered", () => {
+    expect(transitionPreviewRegistry.all().length).toBe(7);
+  });
+
+  describe("fade handler", () => {
+    const handler = transitionPreviewRegistry.get("fade")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ opacity: 0 });
+      expect(handler.computeIncomingStyle(1)).toEqual({ opacity: 1 });
+      expect(handler.computeIncomingStyle(0.5)).toEqual({ opacity: 0.5 });
+    });
+
+    test("computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle!(0)).toEqual({ opacity: 1 });
+      expect(handler.computeOutgoingStyle!(1)).toEqual({ opacity: 0 });
+    });
+  });
+
+  describe("fade-black handler", () => {
+    const handler = transitionPreviewRegistry.get("fade-black")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ opacity: 0 });
+      expect(handler.computeIncomingStyle(0.5)).toEqual({ opacity: 0 });
+      expect(handler.computeIncomingStyle(1)).toEqual({ opacity: 1 });
+    });
+
+    test("computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle!(0)).toEqual({ opacity: 1 });
+      expect(handler.computeOutgoingStyle!(0.5)).toEqual({ opacity: 0 });
+    });
+  });
+
+  describe("fade-white handler", () => {
+    const handler = transitionPreviewRegistry.get("fade-white")!;
+
+    test("computeIncomingStyle at progress 0.25 has brightness filter", () => {
+      const style = handler.computeIncomingStyle(0.25);
+      expect(style.filter).toBe("brightness(5)");
+    });
+
+    test("computeIncomingStyle at progress 0.75 has no filter", () => {
+      const style = handler.computeIncomingStyle(0.75);
+      expect(style.filter).toBeUndefined();
+    });
+
+    test("computeOutgoingStyle at progress 0.25 has brightness filter", () => {
+      const style = handler.computeOutgoingStyle!(0.25);
+      expect(style.filter).toBe("brightness(5)");
+    });
+
+    test("computeOutgoingStyle at progress 0.75 has opacity 0", () => {
+      const style = handler.computeOutgoingStyle!(0.75);
+      expect(style.opacity).toBe(0);
+    });
+  });
+
+  describe("slide-left handler", () => {
+    const handler = transitionPreviewRegistry.get("slide-left")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ transform: "translateX(100%)" });
+      expect(handler.computeIncomingStyle(1)).toEqual({ transform: "translateX(0%)" });
+    });
+
+    test("has no computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle).toBeUndefined();
+    });
+  });
+
+  describe("slide-right handler", () => {
+    const handler = transitionPreviewRegistry.get("slide-right")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ transform: "translateX(-100%)" });
+      expect(handler.computeIncomingStyle(1)).toEqual({ transform: "translateX(0%)" });
+    });
+
+    test("has no computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle).toBeUndefined();
+    });
+  });
+
+  describe("slide-up handler", () => {
+    const handler = transitionPreviewRegistry.get("slide-up")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ transform: "translateY(100%)" });
+      expect(handler.computeIncomingStyle(1)).toEqual({ transform: "translateY(0%)" });
+    });
+
+    test("has no computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle).toBeUndefined();
+    });
+  });
+
+  describe("slide-down handler", () => {
+    const handler = transitionPreviewRegistry.get("slide-down")!;
+
+    test("computeIncomingStyle", () => {
+      expect(handler.computeIncomingStyle(0)).toEqual({ transform: "translateY(-100%)" });
+      expect(handler.computeIncomingStyle(1)).toEqual({ transform: "translateY(0%)" });
+    });
+
+    test("has no computeOutgoingStyle", () => {
+      expect(handler.computeOutgoingStyle).toBeUndefined();
+    });
+  });
+});
+
+describe("computeTransitionStyle", () => {
+  function makeProject(clips: Clip[]): Project {
+    return {
+      id: "p1",
+      name: "Test",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      assets: [],
+      sequence: {
+        tracks: [{ id: "t1", clips }],
+      },
+      settings: { durationMs: 10000, canvasWidth: 1920, canvasHeight: 1080 },
+    };
+  }
+
+  test("clip with fade transition at 50% incoming progress returns opacity 0.5", () => {
+    const clip: Clip = {
+      id: "c1",
+      clipKind: "video",
+      assetId: "a1",
+      startMs: 0,
+      durationMs: 5000,
+      inMs: 0,
+      outMs: 5000,
+      transition: { type: "fade", durationMs: 1000 },
+    };
+    const project = makeProject([clip]);
+    // At 500ms, progress = 500/1000 = 0.5
+    const style = computeTransitionStyle(clip, project, 500);
+    expect(style.opacity).toBe(0.5);
+  });
+
+  test("clip with no transition returns empty object", () => {
+    const clip: Clip = {
+      id: "c2",
+      clipKind: "video",
+      assetId: "a1",
+      startMs: 0,
+      durationMs: 5000,
+      inMs: 0,
+      outMs: 5000,
+    };
+    const project = makeProject([clip]);
+    const style = computeTransitionStyle(clip, project, 2500);
+    expect(style).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
テスト監査で発見された HIGH リスクのカバレッジギャップ5件を修正。

### 追加テスト
1. **Transition preview**: 全7種の incoming/outgoing スタイル計算 + `computeTransitionStyle` 統合テスト
2. **p5js detector**: `.p5.js` 判定、非該当パターン、priority テスト
3. **p5js frontend registration**: tick strategy, asset kind, renderer 登録テスト
4. **p5js pipeline E2E**: sketch → p5jsPrepare → webRender → MP4 のフルパイプラインテスト (Chromium + ffmpeg)

### その他
- Issue #64 に「data model のみ、動作は #9/#10 で実装」の注記を追加

## Test plan
- [x] 356 tests pass (329 → 356, +27 new tests)
- [x] 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)