### PR TITLE
Inspector: change asset assignment for any clip

### DIFF
--- a/app/frontend/src/components/InspectorPanel.test.ts
+++ b/app/frontend/src/components/InspectorPanel.test.ts
@@ -1,0 +1,199 @@
+import { describe, test, expect } from "bun:test";
+import type { Asset, Clip } from "@video/shared";
+import { getCompatibleAssets, computeAssetChangeUpdates } from "./InspectorPanel";
+
+const videoAsset1: Asset = {
+  id: "v1",
+  kind: "video",
+  originalPath: "assets/video1.mp4",
+  durationMs: 5000,
+};
+
+const videoAsset2: Asset = {
+  id: "v2",
+  kind: "video",
+  originalPath: "assets/video2.mp4",
+  durationMs: 10000,
+};
+
+const imageAsset: Asset = {
+  id: "i1",
+  kind: "image",
+  originalPath: "assets/photo.jpg",
+};
+
+const audioAsset: Asset = {
+  id: "a1",
+  kind: "audio",
+  originalPath: "assets/bgm.mp3",
+  durationMs: 60000,
+};
+
+const allAssets = [videoAsset1, videoAsset2, imageAsset, audioAsset];
+
+const makeClip = (overrides: Partial<Clip> = {}): Clip => ({
+  id: "clip1",
+  clipKind: "video",
+  assetId: "v1",
+  startMs: 0,
+  durationMs: 5000,
+  inMs: 0,
+  outMs: 5000,
+  ...overrides,
+});
+
+describe("getCompatibleAssets", () => {
+  test("returns only video assets for video clip kind", () => {
+    const result = getCompatibleAssets(allAssets, "video");
+    expect(result).toEqual([videoAsset1, videoAsset2]);
+  });
+
+  test("returns only image assets for image clip kind", () => {
+    const result = getCompatibleAssets(allAssets, "image");
+    expect(result).toEqual([imageAsset]);
+  });
+
+  test("returns only audio assets for audio clip kind", () => {
+    const result = getCompatibleAssets(allAssets, "audio");
+    expect(result).toEqual([audioAsset]);
+  });
+
+  test("returns empty array for title clip kind", () => {
+    const result = getCompatibleAssets(allAssets, "title");
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for unknown clip kind", () => {
+    const result = getCompatibleAssets(allAssets, "unknown");
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when no assets exist", () => {
+    const result = getCompatibleAssets([], "video");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("computeAssetChangeUpdates", () => {
+  test("switching to a new video asset updates assetId and timing", () => {
+    const clip = makeClip({ assetId: "v1", durationMs: 5000, inMs: 1000, outMs: 4000 });
+    const updates = computeAssetChangeUpdates(videoAsset2, clip);
+    expect(updates).toEqual({
+      assetId: "v2",
+      durationMs: 10000,
+      inMs: 0,
+      outMs: 10000,
+    });
+  });
+
+  test("switching to an image asset uses default duration", () => {
+    const clip = makeClip({ clipKind: "image", assetId: "i1" });
+    const updates = computeAssetChangeUpdates(imageAsset, clip);
+    // image has no durationMs, so should use defaultDurationMs (3000)
+    expect(updates).toEqual({
+      assetId: "i1",
+      durationMs: 3000,
+      inMs: 0,
+      outMs: 3000,
+    });
+  });
+
+  test("switching to an audio asset uses its durationMs", () => {
+    const clip = makeClip({ clipKind: "audio", assetId: "a1" });
+    const updates = computeAssetChangeUpdates(audioAsset, clip);
+    expect(updates).toEqual({
+      assetId: "a1",
+      durationMs: 60000,
+      inMs: 0,
+      outMs: 60000,
+    });
+  });
+
+  test("switching to undefined (no asset) clears assetId only", () => {
+    const clip = makeClip();
+    const updates = computeAssetChangeUpdates(undefined, clip);
+    expect(updates).toEqual({ assetId: "" });
+  });
+
+  test("switching from empty asset to a video asset", () => {
+    const clip = makeClip({ assetId: "", durationMs: 3000, inMs: 0, outMs: 3000 });
+    const updates = computeAssetChangeUpdates(videoAsset1, clip);
+    expect(updates).toEqual({
+      assetId: "v1",
+      durationMs: 5000,
+      inMs: 0,
+      outMs: 5000,
+    });
+  });
+
+  test("clamps duration to maxDurationMs when clip would exceed project boundary", () => {
+    const clip = makeClip({ startMs: 8000, durationMs: 2000 });
+    // videoAsset2.durationMs = 10000, startMs=8000 + 10000 = 18000 > maxDurationMs=10000
+    const updates = computeAssetChangeUpdates(videoAsset2, clip, 10000);
+    expect(updates).toEqual({
+      assetId: "v2",
+      durationMs: 2000,  // 10000 - 8000
+      inMs: 0,
+      outMs: 2000,
+    });
+  });
+
+  test("no clamping when clip fits within maxDurationMs", () => {
+    const clip = makeClip({ startMs: 0, durationMs: 5000 });
+    const updates = computeAssetChangeUpdates(videoAsset2, clip, 20000);
+    expect(updates).toEqual({
+      assetId: "v2",
+      durationMs: 10000,
+      inMs: 0,
+      outMs: 10000,
+    });
+  });
+
+  test("clears transition and restores startMs when switching asset on clip with transition", () => {
+    const clip = makeClip({
+      startMs: 700,  // shifted by transition overlap
+      durationMs: 5000,
+      transition: { type: "fade", durationMs: 300 },
+    });
+    const updates = computeAssetChangeUpdates(videoAsset2, clip);
+    expect(updates).toEqual({
+      assetId: "v2",
+      durationMs: 10000,
+      inMs: 0,
+      outMs: 10000,
+      transition: undefined,
+      startMs: 1000,  // 700 + 300 (restored)
+    });
+  });
+
+  test("clears transition and clamps when switching asset exceeds maxDurationMs", () => {
+    const clip = makeClip({
+      startMs: 4700,  // shifted by 300ms transition overlap
+      durationMs: 5000,
+      transition: { type: "fade", durationMs: 300 },
+    });
+    // After transition clear: startMs = 5000. videoAsset2.durationMs=10000, 5000+10000=15000 > 10000
+    const updates = computeAssetChangeUpdates(videoAsset2, clip, 10000);
+    expect(updates).toEqual({
+      assetId: "v2",
+      durationMs: 5000,  // 10000 - 5000
+      inMs: 0,
+      outMs: 5000,
+      transition: undefined,
+      startMs: 5000,
+    });
+  });
+
+  test("clearing asset on clip with transition also clears transition", () => {
+    const clip = makeClip({
+      startMs: 700,
+      transition: { type: "fade", durationMs: 300 },
+    });
+    const updates = computeAssetChangeUpdates(undefined, clip);
+    expect(updates).toEqual({
+      assetId: "",
+      transition: undefined,
+      startMs: 1000,
+    });
+  });
+});

--- a/app/frontend/src/components/InspectorPanel.tsx
+++ b/app/frontend/src/components/InspectorPanel.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import type { Project, Clip, Asset, ClipTransition } from "@video/shared";
+import { DEFAULT_IMAGE_DURATION_MS } from "@video/shared";
 import { theme, inputStyle, sectionHeadingStyle } from "../theme";
 import { clipKindRegistry } from "../lib/clip-kind-registry";
+import { assetKindRegistry } from "../lib/asset-kind-registry";
 import { inspectorEditorRegistry } from "../lib/inspector-editor-registry";
 
 type Props = {
@@ -24,6 +26,53 @@ function findClipAndAsset(
     }
   }
   return null;
+}
+
+/**
+ * Return assets whose kind is compatible with the given clip kind.
+ * Clip kind maps 1:1 to asset kind (e.g. "video" clip -> "video" assets).
+ */
+export function getCompatibleAssets(assets: Asset[], clipKind: string): Asset[] {
+  return assets.filter((a) => a.kind === clipKind);
+}
+
+/**
+ * Compute updated timing properties when switching to a new asset.
+ * Returns the partial Clip updates to apply.
+ */
+export function computeAssetChangeUpdates(
+  newAsset: Asset | undefined,
+  clip: Clip,
+  maxDurationMs?: number,
+): Partial<Clip> {
+  // Clear transition if present — overlap position is no longer valid
+  const transitionCleanup: Partial<Clip> = clip.transition
+    ? { transition: undefined, startMs: clip.startMs + clip.transition.durationMs }
+    : {};
+
+  if (!newAsset) {
+    // Switching to "(No asset)" — keep current timing, just clear assetId
+    return { assetId: "", ...transitionCleanup };
+  }
+
+  const descriptor = assetKindRegistry.get(newAsset.kind);
+  const rawDurationMs = descriptor?.hasDuration
+    ? (newAsset.durationMs ?? descriptor.defaultDurationMs ?? DEFAULT_IMAGE_DURATION_MS)
+    : (descriptor?.defaultDurationMs ?? DEFAULT_IMAGE_DURATION_MS);
+
+  // Clamp to project boundary
+  const effectiveStartMs = transitionCleanup.startMs ?? clip.startMs;
+  const newDurationMs = maxDurationMs != null && effectiveStartMs + rawDurationMs > maxDurationMs
+    ? Math.max(100, maxDurationMs - effectiveStartMs)
+    : rawDurationMs;
+
+  return {
+    assetId: newAsset.id,
+    durationMs: newDurationMs,
+    inMs: 0,
+    outMs: newDurationMs,
+    ...transitionCleanup,
+  };
 }
 
 export function InspectorPanel({ project, selectedClipId, onUpdateClip, onMoveClip, onSetTransition }: Props) {
@@ -74,6 +123,15 @@ export function InspectorPanel({ project, selectedClipId, onUpdateClip, onMoveCl
           {asset?.codec && <Row label="Codec" value={asset.codec} />}
         </tbody>
       </table>
+
+      {hasAsset && onUpdateClip && (
+        <AssetSelector
+          clip={clip}
+          assets={project.assets}
+          maxDurationMs={project.settings.durationMs}
+          onChangeAsset={(updates) => onUpdateClip(clip.id, updates)}
+        />
+      )}
 
       {onMoveClip && (
         <StartEndEditor clip={clip} onMoveClip={(newStartMs) => onMoveClip(clip.id, newStartMs)} />
@@ -145,6 +203,56 @@ function StartEndEditor({
           />
         </div>
       </div>
+    </div>
+  );
+}
+
+function AssetSelector({
+  clip,
+  assets,
+  maxDurationMs,
+  onChangeAsset,
+}: {
+  clip: Clip;
+  assets: Asset[];
+  maxDurationMs?: number;
+  onChangeAsset: (updates: Partial<Clip>) => void;
+}) {
+  const compatibleAssets = getCompatibleAssets(assets, clip.clipKind);
+
+  if (compatibleAssets.length === 0 && clip.assetId === "") {
+    return (
+      <div style={{ marginTop: "8px", color: theme.textMuted, fontSize: "11px" }}>
+        Asset: (empty)
+      </div>
+    );
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newAssetId = e.target.value;
+    if (newAssetId === clip.assetId) return;
+    const newAsset = newAssetId === "" ? undefined : assets.find((a) => a.id === newAssetId);
+    onChangeAsset(computeAssetChangeUpdates(newAsset, clip, maxDurationMs));
+  };
+
+  return (
+    <div style={{ marginTop: "8px" }}>
+      <label style={{ color: theme.text, display: "block", marginBottom: "4px" }}>
+        Asset
+      </label>
+      <select
+        value={clip.assetId}
+        onChange={handleChange}
+        style={{ ...inputStyle, width: "100%" }}
+        data-testid="asset-selector"
+      >
+        <option value="">(No asset)</option>
+        {compatibleAssets.map((a) => (
+          <option key={a.id} value={a.id}>
+            {a.originalPath.split("/").pop() ?? a.id}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add asset selector dropdown in inspector panel for all clip kinds with `hasAsset: true`
- Filter dropdown to show only assets compatible with the clip's kind
- "(No asset)" option always available to clear assignment
- Duration clamped to project boundary when switching to longer assets
- Transitions cleared automatically when asset changes (overlap position becomes invalid)

## Test plan
- [x] 16 unit tests for `getCompatibleAssets` and `computeAssetChangeUpdates`
- [x] Edge cases: transition cleanup, maxDurationMs clamping, empty-to-real, real-to-empty
- [x] All 384 tests pass
- [x] Playwright verification of editor UI

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)