### PR TITLE
Add clip by double-clicking empty timeline area

### DIFF
--- a/app/frontend/src/components/ClipKindPopup.tsx
+++ b/app/frontend/src/components/ClipKindPopup.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from "react";
+import { clipKindRegistry } from "../lib/clip-kind-registry";
+import { theme } from "../theme";
+
+type Props = {
+  position: { x: number; y: number };
+  onSelect: (clipKind: string) => void;
+  onClose: () => void;
+};
+
+export function ClipKindPopup({ position, onSelect, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [adjustedPos, setAdjustedPos] = useState(position);
+
+  // Clamp to viewport after mount
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = position.x + rect.width > window.innerWidth
+      ? Math.max(0, window.innerWidth - rect.width - 8)
+      : position.x;
+    const y = position.y + rect.height > window.innerHeight
+      ? Math.max(0, window.innerHeight - rect.height - 8)
+      : position.y;
+    if (x !== position.x || y !== position.y) {
+      setAdjustedPos({ x, y });
+    }
+  }, [position]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const kinds = clipKindRegistry.all();
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "fixed",
+        left: adjustedPos.x,
+        top: adjustedPos.y,
+        background: theme.bgPanel,
+        border: `1px solid ${theme.border}`,
+        borderRadius: "6px",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+        padding: "4px 0",
+        zIndex: 1000,
+        minWidth: "120px",
+      }}
+    >
+      <div
+        style={{
+          padding: "4px 10px",
+          fontSize: "10px",
+          color: theme.textMuted,
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+        }}
+      >
+        Add clip
+      </div>
+      {kinds.map((desc) => (
+        <button
+          key={desc.kind}
+          onClick={() => onSelect(desc.kind)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            width: "100%",
+            padding: "6px 10px",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "12px",
+            color: theme.text,
+            textAlign: "left",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = theme.bgHover;
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "none";
+          }}
+        >
+          <span
+            style={{
+              display: "inline-block",
+              width: "14px",
+              height: "14px",
+              borderRadius: "3px",
+              background: desc.clipColor,
+              flexShrink: 0,
+            }}
+          />
+          <span>{desc.kind}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/frontend/src/components/Timeline.tsx
+++ b/app/frontend/src/components/Timeline.tsx
@@ -5,6 +5,7 @@ import { TimelineTrack } from "./TimelineTrack";
 import { Playhead } from "./Playhead";
 import { ContextMenu } from "./ContextMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { ClipKindPopup } from "./ClipKindPopup";
 import { useTimelineZoom } from "../hooks/useTimelineZoom";
 import { theme } from "../theme";
 
@@ -20,6 +21,7 @@ type Props = {
   onAddTrack?: () => void;
   onDeleteTrack?: (trackId: string) => void;
   onSetTransition?: (clipId: string, transition: ClipTransition | undefined) => void;
+  onAddEmptyClip?: (clipKind: string, startMs: number, trackId: string) => void;
 };
 
 function getTimelineDuration(project: Project): number {
@@ -38,6 +40,7 @@ export function Timeline({
   onAddTrack,
   onDeleteTrack,
   onSetTransition,
+  onAddEmptyClip,
 }: Props) {
   const { msToPx, pxToMs, zoomIn, zoomOut } = useTimelineZoom();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -54,6 +57,12 @@ export function Timeline({
     y: number;
   } | null>(null);
   const [confirmDeleteTrackId, setConfirmDeleteTrackId] = useState<string | null>(null);
+  const [clipKindPopup, setClipKindPopup] = useState<{
+    trackId: string;
+    timeMs: number;
+    x: number;
+    y: number;
+  } | null>(null);
   const allTrackIds = project.sequence.tracks.map((t: Track) => t.id);
 
   const handleClipContextMenu = useCallback(
@@ -120,6 +129,14 @@ export function Timeline({
       onTrimClip?.(clipId, side, deltaMs);
     },
     [onTrimClip],
+  );
+
+  const handleTrackDoubleClick = useCallback(
+    (trackId: string, timeMs: number, position: { x: number; y: number }) => {
+      if (!onAddEmptyClip) return;
+      setClipKindPopup({ trackId, timeMs, x: position.x, y: position.y });
+    },
+    [onAddEmptyClip],
   );
 
   // Handle Delete key
@@ -256,6 +273,7 @@ export function Timeline({
                   isDropTarget={dragTargetTrackId === track.id}
                   onDragTrackChange={setDragTargetTrackId}
                   onSetTransition={onSetTransition}
+                  onTrackDoubleClick={handleTrackDoubleClick}
                 />
               ))
             )}
@@ -360,6 +378,17 @@ export function Timeline({
             setConfirmDeleteTrackId(null);
           }}
           onCancel={() => setConfirmDeleteTrackId(null)}
+        />
+      )}
+
+      {clipKindPopup && onAddEmptyClip && (
+        <ClipKindPopup
+          position={{ x: clipKindPopup.x, y: clipKindPopup.y }}
+          onSelect={(clipKind) => {
+            onAddEmptyClip(clipKind, Math.max(0, Math.round(clipKindPopup.timeMs)), clipKindPopup.trackId);
+            setClipKindPopup(null);
+          }}
+          onClose={() => setClipKindPopup(null)}
         />
       )}
     </div>

--- a/app/frontend/src/components/TimelineTrack.tsx
+++ b/app/frontend/src/components/TimelineTrack.tsx
@@ -22,6 +22,7 @@ type Props = {
   isDropTarget?: boolean;
   onDragTrackChange?: (targetTrackId: string | null) => void;
   onSetTransition?: (clipId: string, transition: ClipTransition | undefined) => void;
+  onTrackDoubleClick?: (trackId: string, timeMs: number, position: { x: number; y: number }) => void;
 };
 
 export function TimelineTrack({
@@ -42,6 +43,7 @@ export function TimelineTrack({
   isDropTarget,
   onDragTrackChange,
   onSetTransition,
+  onTrackDoubleClick,
 }: Props) {
   const assetMap = new Map(assets.map((a) => [a.id, a]));
   const sortedClips = useMemo(
@@ -74,6 +76,19 @@ export function TimelineTrack({
         {trackIndex + 1}
       </div>
       <div
+        onMouseDown={(e) => {
+          // Prevent seek handler from firing when interacting with track content
+          if (e.detail >= 2) e.stopPropagation();
+        }}
+        onDoubleClick={(e) => {
+          // Only trigger when clicking empty area (not a clip)
+          if (e.target !== e.currentTarget) return;
+          e.stopPropagation();
+          const rect = e.currentTarget.getBoundingClientRect();
+          const x = e.clientX - rect.left;
+          const timeMs = pxToMs(x);
+          onTrackDoubleClick?.(track.id, timeMs, { x: e.clientX, y: e.clientY });
+        }}
         style={{
           position: "relative",
           flex: 1,

--- a/app/frontend/src/hooks/useProjectEditor.ts
+++ b/app/frontend/src/hooks/useProjectEditor.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import type { Project, Asset, Clip, ClipText, ClipTransition, Sequence } from "@video/shared";
+import { theme } from "../theme";
 import * as SeqOps from "../lib/sequence-ops";
 
 export function useProjectEditor(
@@ -57,6 +58,16 @@ export function useProjectEditor(
     [sequence, pushState, maxDurationMs],
   );
 
+  const addEmptyClip = useCallback(
+    (clipKind: string, startMs: number, targetTrackId?: string) => {
+      const text = clipKind === "title"
+        ? { value: "Text", fontSize: 48, color: theme.white, backgroundColor: theme.black } as ClipText
+        : undefined;
+      pushState(SeqOps.addEmptyClip(sequence, clipKind, startMs, 3000, maxDurationMs, targetTrackId, text));
+    },
+    [sequence, pushState, maxDurationMs],
+  );
+
   const updateClip = useCallback(
     (clipId: string, updates: Partial<Clip>) => {
       pushState(SeqOps.updateClip(sequence, clipId, updates));
@@ -81,6 +92,7 @@ export function useProjectEditor(
     moveClip,
     trimClip,
     addTextClip,
+    addEmptyClip,
     updateClip,
     setTransition,
   };

--- a/app/frontend/src/lib/__snapshots__/sequence-ops.regression.test.ts.snap
+++ b/app/frontend/src/lib/__snapshots__/sequence-ops.regression.test.ts.snap
@@ -585,3 +585,162 @@ exports[`editor operation regression workflow: clamp empty-asset clip to duratio
   ],
 }
 `;
+
+exports[`editor operation regression workflow: addEmptyClip to existing track 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "",
+          "clipKind": "video",
+          "durationMs": 3000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 6000,
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;
+
+exports[`editor operation regression workflow: addEmptyClip creates new track when no target 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "",
+          "clipKind": "image",
+          "durationMs": 3000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 1000,
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;
+
+exports[`editor operation regression workflow: addEmptyClip with title sets text 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "",
+          "clipKind": "title",
+          "durationMs": 3000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 0,
+          "text": {
+            "backgroundColor": "black",
+            "color": "white",
+            "fontSize": 48,
+            "value": "Text",
+          },
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;
+
+exports[`editor operation regression workflow: addEmptyClip clamped by maxDuration 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "",
+          "clipKind": "video",
+          "durationMs": 1000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 1000,
+          "startMs": 9000,
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;
+
+exports[`editor operation regression workflow: addEmptyClip then move 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "",
+          "clipKind": "video",
+          "durationMs": 3000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 5000,
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;
+
+exports[`editor operation regression workflow: addEmptyClip multiple kinds on same track 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "",
+          "clipKind": "video",
+          "durationMs": 2000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 2000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "",
+          "clipKind": "image",
+          "durationMs": 2000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 2000,
+          "startMs": 3000,
+        },
+        {
+          "assetId": "",
+          "clipKind": "audio",
+          "durationMs": 2000,
+          "id": "clip-2",
+          "inMs": 0,
+          "outMs": 2000,
+          "startMs": 6000,
+        },
+      ],
+      "id": "track-0",
+    },
+  ],
+}
+`;

--- a/app/frontend/src/lib/sequence-ops.regression.test.ts
+++ b/app/frontend/src/lib/sequence-ops.regression.test.ts
@@ -4,6 +4,7 @@ import { assetKindRegistry } from "./asset-kind-registry";
 import { builtinPlugin } from "./builtin-plugin";
 import {
   addClipFromAsset,
+  addEmptyClip,
   moveClip,
   trimClip,
   addTextClip,
@@ -427,6 +428,92 @@ describe("editor operation regression", () => {
     };
 
     seq = clampClipsToDuration(seq, 3000);
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip to existing track", () => {
+    let seq: Sequence = { tracks: [] };
+
+    seq = addClipFromAsset(seq, videoAsset, 10000);
+
+    // Add empty video clip at 6000ms on the same track
+    const trackId = seq.tracks[0].id;
+    seq = addEmptyClip(seq, "video", 6000, 3000, 10000, trackId);
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip creates new track when no target", () => {
+    let seq: Sequence = { tracks: [] };
+
+    seq = addEmptyClip(seq, "image", 1000, 3000, 10000);
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip with title sets text", () => {
+    let seq: Sequence = { tracks: [] };
+
+    seq = addEmptyClip(seq, "title", 0, 3000, 10000, undefined, {
+      value: "Text",
+      fontSize: 48,
+      color: "white",
+      backgroundColor: "black",
+    });
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip clamped by maxDuration", () => {
+    let seq: Sequence = { tracks: [] };
+
+    // Start at 9000ms with 3000ms duration, should clamp to 1000ms
+    seq = addEmptyClip(seq, "video", 9000, 3000, 10000);
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip rejected when overlapping", () => {
+    let seq: Sequence = { tracks: [] };
+
+    seq = addClipFromAsset(seq, videoAsset, 10000);
+
+    // Try to add empty clip overlapping with existing video clip (0-5000)
+    const trackId = seq.tracks[0].id;
+    const before = stabilize(seq);
+    seq = addEmptyClip(seq, "image", 2000, 3000, 10000, trackId);
+
+    // Should be unchanged because of overlap
+    expect(stabilize(seq)).toEqual(before);
+  });
+
+  test("workflow: addEmptyClip rejected when beyond maxDuration", () => {
+    let seq: Sequence = { tracks: [] };
+
+    const before = stabilize(seq);
+    seq = addEmptyClip(seq, "video", 10000, 3000, 10000);
+
+    // startMs >= maxDurationMs, should be rejected (no tracks created)
+    expect(seq.tracks.length).toBe(0);
+  });
+
+  test("workflow: addEmptyClip then move", () => {
+    let seq: Sequence = { tracks: [] };
+
+    seq = addEmptyClip(seq, "video", 0, 3000, 10000);
+    const clipId = seq.tracks[0].clips[0].id;
+    seq = moveClip(seq, clipId, 5000, 10000);
+
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("workflow: addEmptyClip multiple kinds on same track", () => {
+    let seq: Sequence = { tracks: [{ id: "t1", clips: [] }] };
+
+    seq = addEmptyClip(seq, "video", 0, 2000, 10000, "t1");
+    seq = addEmptyClip(seq, "image", 3000, 2000, 10000, "t1");
+    seq = addEmptyClip(seq, "audio", 6000, 2000, 10000, "t1");
 
     expect(stabilize(seq)).toMatchSnapshot();
   });

--- a/app/frontend/src/lib/sequence-ops.ts
+++ b/app/frontend/src/lib/sequence-ops.ts
@@ -261,6 +261,61 @@ export function addTextClip(
   return { ...sequence, tracks };
 }
 
+export function addEmptyClip(
+  sequence: Sequence,
+  clipKind: string,
+  startMs: number,
+  durationMs: number,
+  maxDurationMs?: number,
+  targetTrackId?: string,
+  text?: ClipText,
+): Sequence {
+  // Reject if start is beyond the limit
+  if (maxDurationMs != null && startMs >= maxDurationMs) {
+    return sequence;
+  }
+
+  // Clamp duration
+  let clampedDuration = durationMs;
+  if (maxDurationMs != null && startMs + clampedDuration > maxDurationMs) {
+    clampedDuration = maxDurationMs - startMs;
+  }
+
+  const tracks = sequence.tracks.map((t: Track) => ({ ...t, clips: [...t.clips] }));
+  let track: Track | undefined;
+  if (targetTrackId) {
+    track = tracks.find((t: Track) => t.id === targetTrackId);
+  }
+  if (!track) {
+    track = { id: generateId(), clips: [] };
+    tracks.push(track);
+  }
+
+  // Check for overlap with existing clips on this track
+  const hasOverlap = track.clips.some((c: Clip) => {
+    const cEnd = c.startMs + c.durationMs;
+    return startMs < cEnd && startMs + clampedDuration > c.startMs;
+  });
+  if (hasOverlap) {
+    return sequence;
+  }
+
+  const clip: Clip = {
+    id: generateId(),
+    clipKind,
+    assetId: "",
+    startMs,
+    durationMs: clampedDuration,
+    inMs: 0,
+    outMs: clampedDuration,
+    ...(text ? { text } : {}),
+  };
+
+  track.clips.push(clip);
+  track.clips.sort((a: Clip, b: Clip) => a.startMs - b.startMs);
+  return { ...sequence, tracks };
+}
+
 export function clampClipsToDuration(
   sequence: Sequence,
   maxDurationMs: number,

--- a/app/frontend/src/pages/EditorPage.tsx
+++ b/app/frontend/src/pages/EditorPage.tsx
@@ -108,7 +108,7 @@ function EditorPageLoaded({
     project.sequence,
   );
 
-  const { addClipFromAsset, removeClip, moveClip, trimClip, addTextClip, updateClip, setTransition } =
+  const { addClipFromAsset, removeClip, moveClip, trimClip, addTextClip, addEmptyClip, updateClip, setTransition } =
     useProjectEditor(project, sequence, pushState);
 
   const { saveStatus } = useAutoSave(project.id, sequence);
@@ -146,6 +146,34 @@ function EditorPageLoaded({
       addTextClip(startMs, durationMs, text, selectedTrackId ?? undefined);
     },
     [addTextClip, selectedTrackId],
+  );
+
+  const pendingAutoSelectRef = useRef(false);
+  const prevClipIdsRef = useRef(new Set<string>());
+
+  // Track clip IDs for auto-selection of newly added empty clips
+  useEffect(() => {
+    const currentIds = new Set(
+      sequence.tracks.flatMap((t) => t.clips.map((c) => c.id)),
+    );
+    if (pendingAutoSelectRef.current && prevClipIdsRef.current.size > 0) {
+      for (const id of currentIds) {
+        if (!prevClipIdsRef.current.has(id)) {
+          onSelectClip(id);
+          break;
+        }
+      }
+      pendingAutoSelectRef.current = false;
+    }
+    prevClipIdsRef.current = currentIds;
+  }, [sequence, onSelectClip]);
+
+  const handleAddEmptyClip = useCallback(
+    (clipKind: string, startMs: number, trackId: string) => {
+      pendingAutoSelectRef.current = true;
+      addEmptyClip(clipKind, startMs, trackId);
+    },
+    [addEmptyClip],
   );
 
   const currentProject: Project = { ...project, sequence };
@@ -359,6 +387,7 @@ function EditorPageLoaded({
           onAddTrack={handleAddTrack}
           onDeleteTrack={handleDeleteTrack}
           onSetTransition={setTransition}
+          onAddEmptyClip={handleAddEmptyClip}
         />
       }
     />


### PR DESCRIPTION
## Summary
- Double-click empty space on a timeline track to open a clip kind popup
- Select video/image/audio/title/p5.js to create an empty clip at that position
- Popup clamps to viewport edges, closes on Escape or click-outside
- Prevents seek-on-double-click by stopping mousedown propagation
- New clip is auto-selected in inspector for immediate asset assignment

## Test plan
- [x] 8 snapshot regression tests for addEmptyClip operations
- [x] Edge cases: overlap rejection, boundary clamping, title defaults, multiple kinds
- [x] All 392 tests pass
- [ ] Playwright verification of double-click UX

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)