### PR TITLE
p5.js: inline code editor in inspector

### DIFF
--- a/app/backend/src/app.ts
+++ b/app/backend/src/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { projects } from "./routes/projects";
 import { assets } from "./routes/assets";
+import { assetContent } from "./routes/asset-content";
 import { jobsRouter } from "./routes/jobs";
 import { media } from "./routes/media";
 import { exports } from "./routes/exports";
@@ -17,6 +18,7 @@ app.onError((err, c) => {
 
 app.route("/api/projects", projects);
 app.route("/api/projects", exports);
+app.route("/api/projects", assetContent);
 app.route("/api/assets", assets);
 app.route("/api/jobs", jobsRouter);
 app.route("/media", media);

--- a/app/backend/src/pipeline/steps/p5js-prepare.ts
+++ b/app/backend/src/pipeline/steps/p5js-prepare.ts
@@ -49,8 +49,8 @@ export const p5jsPrepareStep: PipelineStep = {
   canHandle: (ctx) => ctx.asset.kind === "p5js",
 
   async execute(ctx) {
-    // Read the sketch code from the asset file
-    const sketchPath = join(ctx.projectDir, ctx.asset.originalPath);
+    // Read the sketch code from the source file (not the rendered MP4)
+    const sketchPath = join(ctx.projectDir, ctx.asset.sourcePath ?? ctx.asset.originalPath);
     const sketchCode = await readFile(sketchPath, "utf-8");
 
     // Get project dimensions (from shared context or defaults)

--- a/app/backend/src/pipeline/steps/web-render.ts
+++ b/app/backend/src/pipeline/steps/web-render.ts
@@ -142,7 +142,10 @@ export const webRenderStep: PipelineStep = {
 
         ctx.reportProgress(1.0);
 
-        // 7. Update asset's originalPath to point to the rendered MP4
+        // 7. Preserve original source path and update originalPath to rendered MP4
+        if (!ctx.asset.sourcePath) {
+          ctx.asset.sourcePath = ctx.asset.originalPath;
+        }
         ctx.asset.originalPath = `assets/${ctx.asset.id}-rendered.mp4`;
       } finally {
         await session.close();

--- a/app/backend/src/routes/asset-content.test.ts
+++ b/app/backend/src/routes/asset-content.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { app } from "../app";
+import { _reset as resetJobQueue } from "../services/job-queue";
+
+let tmpDir: string;
+let projectId: string;
+let assetId: string;
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(path.join(tmpdir(), "video-asset-content-test-"));
+  process.env.WORKSPACE_DIR = tmpDir;
+});
+
+afterAll(async () => {
+  delete process.env.WORKSPACE_DIR;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  resetJobQueue();
+});
+
+async function createProjectWithP5jsAsset(): Promise<{ projectId: string; assetId: string }> {
+  // Create project
+  const createRes = await app.request("/api/projects", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "p5js-test" }),
+  });
+  const project = await createRes.json();
+  const pid = project.id as string;
+
+  // Import a p5.js asset
+  const sketchCode = 'function setup() { createCanvas(400, 400); }\nfunction draw() { background(220); }';
+  const importRes = await app.request(
+    `/api/assets/import?projectId=${pid}&filename=sketch.p5.js`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: sketchCode,
+    },
+  );
+  const importBody = await importRes.json();
+  return { projectId: pid, assetId: importBody.asset.id as string };
+}
+
+describe("routes/asset-content", () => {
+  test("GET /api/projects/:id/assets/:assetId/content reads file content", async () => {
+    const { projectId: pid, assetId: aid } = await createProjectWithP5jsAsset();
+
+    const res = await app.request(`/api/projects/${pid}/assets/${aid}/content`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.content).toContain("createCanvas");
+  });
+
+  test("GET content returns 404 for unknown asset", async () => {
+    const { projectId: pid } = await createProjectWithP5jsAsset();
+
+    const res = await app.request(`/api/projects/${pid}/assets/nonexistent/content`);
+    expect(res.status).toBe(404);
+  });
+
+  test("PUT /api/projects/:id/assets/:assetId/content writes file content", async () => {
+    const { projectId: pid, assetId: aid } = await createProjectWithP5jsAsset();
+
+    const newCode = 'function setup() { createCanvas(800, 600); }';
+    const res = await app.request(`/api/projects/${pid}/assets/${aid}/content`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: newCode }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify it was written
+    const readRes = await app.request(`/api/projects/${pid}/assets/${aid}/content`);
+    const readBody = await readRes.json();
+    expect(readBody.content).toBe(newCode);
+  });
+
+  test("PUT content returns 404 for unknown asset", async () => {
+    const { projectId: pid } = await createProjectWithP5jsAsset();
+
+    const res = await app.request(`/api/projects/${pid}/assets/nonexistent/content`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "test" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("POST /api/projects/:id/assets/:assetId/reprocess enqueues job", async () => {
+    const { projectId: pid, assetId: aid } = await createProjectWithP5jsAsset();
+
+    const res = await app.request(`/api/projects/${pid}/assets/${aid}/reprocess`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.jobId).toBeDefined();
+    expect(typeof body.jobId).toBe("string");
+  });
+
+  test("POST reprocess returns 404 for unknown asset", async () => {
+    const { projectId: pid } = await createProjectWithP5jsAsset();
+
+    const res = await app.request(`/api/projects/${pid}/assets/nonexistent/reprocess`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/backend/src/routes/asset-content.ts
+++ b/app/backend/src/routes/asset-content.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import {
+  readAssetContent,
+  writeAssetContent,
+  reprocessAsset,
+} from "../services/asset-service";
+
+const assetContent = new Hono();
+
+// GET /api/projects/:id/assets/:assetId/content
+assetContent.get("/:id/assets/:assetId/content", async (c) => {
+  const projectId = c.req.param("id");
+  const assetId = c.req.param("assetId");
+  try {
+    const content = await readAssetContent(projectId, assetId);
+    return c.json({ content });
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, 404);
+  }
+});
+
+function errorStatus(err: unknown): 404 | 500 {
+  return (err instanceof Error && err.message.startsWith("Asset not found:")) ? 404 : 500;
+}
+
+// PUT /api/projects/:id/assets/:assetId/content
+assetContent.put("/:id/assets/:assetId/content", async (c) => {
+  const projectId = c.req.param("id");
+  const assetId = c.req.param("assetId");
+  const { content } = await c.req.json<{ content: string }>();
+  if (content == null) {
+    return c.json({ error: "content is required" }, 400);
+  }
+  try {
+    await writeAssetContent(projectId, assetId, content);
+    return c.json({ ok: true });
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, errorStatus(err));
+  }
+});
+
+// POST /api/projects/:id/assets/:assetId/reprocess
+assetContent.post("/:id/assets/:assetId/reprocess", async (c) => {
+  const projectId = c.req.param("id");
+  const assetId = c.req.param("assetId");
+  try {
+    const result = await reprocessAsset(projectId, assetId);
+    return c.json(result, 201);
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, errorStatus(err));
+  }
+});
+
+export { assetContent };

--- a/app/backend/src/services/asset-service.ts
+++ b/app/backend/src/services/asset-service.ts
@@ -2,11 +2,11 @@ import type { Asset, ImportAssetResponse } from "@video/shared";
 import { generateId } from "@video/shared";
 import type { PipelineContext } from "../pipeline/types";
 import { runPipeline } from "../pipeline";
-import { assetsDir, projectDir as getProjectDir, proxyDir, thumbnailDir } from "../utils/paths";
+import { assetsDir, projectDir as getProjectDir, proxyDir, thumbnailDir, resolveUnder } from "../utils/paths";
 import { getProject, saveProject } from "./project-service";
 import { enqueue } from "./job-queue";
 import path from "node:path";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, readFile, writeFile } from "node:fs/promises";
 import { assetDetectorRegistry } from "../lib/asset-detector-registry";
 
 export function createImportTask(
@@ -76,6 +76,69 @@ export async function importAsset(
   });
 
   return { asset, jobId: job.id };
+}
+
+function resolveAssetContentPath(projDir: string, asset: { originalPath: string; sourcePath?: string }): string {
+  const relativePath = asset.sourcePath ?? asset.originalPath;
+  const filePath = resolveUnder(projDir, relativePath);
+  if (!filePath) {
+    throw new Error("Invalid asset path");
+  }
+  return filePath;
+}
+
+export async function readAssetContent(
+  projectId: string,
+  assetId: string,
+): Promise<string> {
+  const project = await getProject(projectId);
+  const asset = project.assets.find((a) => a.id === assetId);
+  if (!asset) {
+    throw new Error(`Asset not found: ${assetId}`);
+  }
+  const projDir = getProjectDir(projectId);
+  const filePath = resolveAssetContentPath(projDir, asset);
+  return readFile(filePath, "utf-8");
+}
+
+export async function writeAssetContent(
+  projectId: string,
+  assetId: string,
+  content: string,
+): Promise<void> {
+  const project = await getProject(projectId);
+  const asset = project.assets.find((a) => a.id === assetId);
+  if (!asset) {
+    throw new Error(`Asset not found: ${assetId}`);
+  }
+  const projDir = getProjectDir(projectId);
+  const filePath = resolveAssetContentPath(projDir, asset);
+  await writeFile(filePath, content, "utf-8");
+}
+
+export async function reprocessAsset(
+  projectId: string,
+  assetId: string,
+): Promise<{ jobId: string }> {
+  const project = await getProject(projectId);
+  const asset = project.assets.find((a) => a.id === assetId);
+  if (!asset) {
+    throw new Error(`Asset not found: ${assetId}`);
+  }
+
+  const projDir = getProjectDir(projectId);
+  const task = createImportTask(projectId, projDir, { ...asset });
+  const job = enqueue(projectId, assetId, async (j) => {
+    const updatedAsset = await task(j);
+    const proj = await getProject(projectId);
+    const idx = proj.assets.findIndex((a) => a.id === assetId);
+    if (idx !== -1) {
+      proj.assets[idx] = updatedAsset;
+      await saveProject(proj);
+    }
+  });
+
+  return { jobId: job.id };
 }
 
 export async function deleteAsset(

--- a/app/frontend/src/components/InspectorPanel.tsx
+++ b/app/frontend/src/components/InspectorPanel.tsx
@@ -103,6 +103,7 @@ export function InspectorPanel({ project, selectedClipId, onUpdateClip, onMoveCl
     clip,
     asset,
     clipKind: clip.clipKind,
+    projectId: project.id,
     onUpdate: (updates: Partial<Clip>) => onUpdateClip?.(clip.id, updates),
     onSetTransition: onSetTransition
       ? (transition: ClipTransition | undefined) => onSetTransition(clip.id, transition)

--- a/app/frontend/src/components/editors/P5jsEditor.tsx
+++ b/app/frontend/src/components/editors/P5jsEditor.tsx
@@ -1,28 +1,160 @@
-import { theme } from "../../theme";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../../api/client";
+import { useJob } from "../../api/jobs";
+import { theme, buttonStyle } from "../../theme";
 import type { InspectorEditorContext } from "../../lib/inspector-editor-registry";
 
-export function P5jsEditor({ asset }: InspectorEditorContext) {
-  if (!asset) return null;
+type ContentResponse = { content: string };
+type ReprocessResponse = { jobId: string };
+
+export function P5jsEditor({ asset, projectId }: InspectorEditorContext) {
+  const queryClient = useQueryClient();
+  const assetId = asset?.id ?? "";
+
+  // Fetch existing code
+  const { data, isLoading } = useQuery({
+    queryKey: ["asset-content", projectId, assetId],
+    queryFn: () =>
+      apiFetch<ContentResponse>(
+        `/api/projects/${projectId}/assets/${assetId}/content`,
+      ),
+    enabled: !!assetId,
+  });
+
+  const [code, setCode] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync fetched content into editor
+  useEffect(() => {
+    if (data?.content != null && !dirty) {
+      setCode(data.content);
+    }
+  }, [data?.content, dirty]);
+
+  // Reset dirty flag when asset changes
+  useEffect(() => {
+    setDirty(false);
+    setActiveJobId(null);
+    setError(null);
+  }, [assetId]);
+
+  // Poll job status
+  const { data: job } = useJob(activeJobId);
+
+  // When job completes, invalidate project to refresh proxy URLs
+  useEffect(() => {
+    if (job?.status === "completed") {
+      queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
+      setActiveJobId(null);
+    }
+  }, [job?.status, projectId, queryClient]);
+
+  const isSaving = activeJobId != null && job?.status !== "completed" && job?.status !== "failed";
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setCode(e.target.value);
+    setDirty(true);
+    setError(null);
+  }, []);
+
+  const savingRef = useRef(false);
+
+  const handleSaveAndRender = useCallback(async () => {
+    if (!assetId || savingRef.current) return;
+    savingRef.current = true;
+    setError(null);
+    try {
+      // Save content
+      await apiFetch(`/api/projects/${projectId}/assets/${assetId}/content`, {
+        method: "PUT",
+        body: JSON.stringify({ content: code }),
+      });
+      setDirty(false);
+
+      // Trigger reprocess
+      const result = await apiFetch<ReprocessResponse>(
+        `/api/projects/${projectId}/assets/${assetId}/reprocess`,
+        { method: "POST" },
+      );
+      setActiveJobId(result.jobId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      savingRef.current = false;
+    }
+  }, [assetId, projectId, code]);
+
+  if (!assetId) {
+    return (
+      <div style={{ marginTop: "8px", color: theme.textMuted, fontSize: "11px" }}>
+        Assign a p5.js asset to edit code.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ marginTop: "8px", color: theme.textMuted, fontSize: "11px" }}>
+        Loading sketch...
+      </div>
+    );
+  }
 
   return (
     <div style={{ marginTop: "8px" }}>
       <label style={{ color: theme.textMuted, display: "block", marginBottom: "4px" }}>
         p5.js Sketch
       </label>
-      <div style={{
-        fontFamily: "monospace",
-        fontSize: "11px",
-        color: theme.text,
-        backgroundColor: theme.bgPanel,
-        border: `1px solid ${theme.border}`,
-        borderRadius: "4px",
-        padding: "8px",
-        maxHeight: "200px",
-        overflow: "auto",
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-all",
-      }}>
-        {asset.originalPath}
+      <textarea
+        value={code}
+        onChange={handleChange}
+        spellCheck={false}
+        data-testid="p5js-code-editor"
+        style={{
+          width: "100%",
+          minHeight: "200px",
+          fontFamily: "monospace",
+          fontSize: "11px",
+          color: theme.text,
+          backgroundColor: theme.bgPanel,
+          border: `1px solid ${theme.border}`,
+          borderRadius: "4px",
+          padding: "8px",
+          resize: "vertical",
+          boxSizing: "border-box",
+          tabSize: 2,
+          lineHeight: 1.4,
+        }}
+      />
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "4px" }}>
+        <button
+          onClick={handleSaveAndRender}
+          disabled={isSaving || !dirty}
+          style={{
+            ...buttonStyle.primary,
+            padding: "4px 12px",
+            fontSize: "11px",
+            opacity: isSaving || !dirty ? 0.5 : 1,
+            cursor: isSaving || !dirty ? "default" : "pointer",
+          }}
+          data-testid="p5js-save-render"
+        >
+          {isSaving ? "Rendering..." : "Save & Render"}
+        </button>
+        {dirty && !isSaving && (
+          <span style={{ color: theme.textMuted, fontSize: "10px" }}>Unsaved changes</span>
+        )}
+        {job?.status === "completed" && !dirty && (
+          <span style={{ color: theme.success, fontSize: "10px" }}>Render complete</span>
+        )}
+        {(job?.status === "failed" || error) && (
+          <span style={{ color: theme.error, fontSize: "10px" }}>
+            {error ?? job?.error ?? "Render failed"}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/app/frontend/src/lib/inspector-editor-registry.test.ts
+++ b/app/frontend/src/lib/inspector-editor-registry.test.ts
@@ -10,6 +10,7 @@ function makeCtx(overrides: Partial<InspectorEditorContext> = {}): InspectorEdit
     clip: { id: "c1", assetId: "a1", startMs: 0, durationMs: 5000, inMs: 0, outMs: 5000 },
     asset: { id: "a1", kind: "video", originalPath: "/test.mp4", durationMs: 10000 },
     clipKind: "video",
+    projectId: "proj-1",
     onUpdate: () => {},
     ...overrides,
   };

--- a/app/frontend/src/lib/inspector-editor-registry.ts
+++ b/app/frontend/src/lib/inspector-editor-registry.ts
@@ -4,6 +4,7 @@ export type InspectorEditorContext = {
   clip: Clip;
   asset: Asset | undefined;
   clipKind: string;
+  projectId: string;
   onUpdate: (updates: Partial<Clip>) => void;
   onSetTransition?: (transition: ClipTransition | undefined) => void;
 };

--- a/app/shared/src/types/asset.ts
+++ b/app/shared/src/types/asset.ts
@@ -7,6 +7,8 @@ export type Asset = {
   id: string;
   kind: AssetKind;
   originalPath: string;
+  /** Original source file path (e.g., .p5.js sketch) preserved when originalPath is overwritten by pipeline */
+  sourcePath?: string;
   proxyPath?: string;
   thumbnailPath?: string;
   width?: number;


### PR DESCRIPTION
## Summary
- Textarea code editor for p5.js sketches in the inspector panel
- Backend APIs: GET/PUT content, POST reprocess
- `Asset.sourcePath` field preserves original `.p5.js` file path after pipeline renders to MP4
- Path traversal protection using `resolveUnder`
- Concurrency guard prevents interleaved saves
- Job polling with status feedback (rendering/complete/failed)

## Test plan
- [x] 6 backend tests for asset content APIs (read, write, reprocess, 404 cases)
- [x] All 398 tests pass
- [ ] Manual verification of Save & Render flow with a p5.js asset

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)