### PR TITLE
Richer Context Menu

### DIFF
--- a/app/frontend/src/components/ContextMenu.tsx
+++ b/app/frontend/src/components/ContextMenu.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useRef } from "react";
 import { theme } from "../theme";
 
-type MenuItem = {
+type MenuAction = {
+  type?: "item";
   label: string;
+  shortcut?: string;
   onClick: () => void;
   disabled?: boolean;
 };
+
+type MenuSeparator = {
+  type: "separator";
+};
+
+export type MenuItem = MenuAction | MenuSeparator;
 
 type Props = {
   items: MenuItem[];
@@ -45,43 +53,72 @@ export function ContextMenu({ items, position, onClose }: Props) {
         borderRadius: "4px",
         padding: "4px 0",
         zIndex: 1000,
-        minWidth: "120px",
+        minWidth: "180px",
         boxShadow: `0 4px 12px ${theme.shadow}`,
       }}
     >
-      {items.map((item, i) => (
-        <button
-          key={i}
-          onClick={() => {
-            if (!item.disabled) {
-              item.onClick();
-              onClose();
-            }
-          }}
-          disabled={item.disabled}
-          style={{
-            display: "block",
-            width: "100%",
-            padding: "6px 16px",
-            background: "none",
-            border: "none",
-            color: item.disabled ? theme.textDisabled : theme.text,
-            fontSize: "12px",
-            textAlign: "left",
-            cursor: item.disabled ? "default" : "pointer",
-          }}
-          onMouseEnter={(e) => {
-            if (!item.disabled) {
-              (e.target as HTMLElement).style.background = theme.bgHover;
-            }
-          }}
-          onMouseLeave={(e) => {
-            (e.target as HTMLElement).style.background = "none";
-          }}
-        >
-          {item.label}
-        </button>
-      ))}
+      {items.map((item, i) => {
+        if (item.type === "separator") {
+          return (
+            <div
+              key={i}
+              style={{
+                height: "1px",
+                background: theme.border,
+                margin: "4px 0",
+              }}
+            />
+          );
+        }
+
+        const action = item as MenuAction;
+        return (
+          <button
+            key={i}
+            onClick={() => {
+              if (!action.disabled) {
+                action.onClick();
+                onClose();
+              }
+            }}
+            disabled={action.disabled}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              width: "100%",
+              padding: "6px 16px",
+              background: "none",
+              border: "none",
+              color: action.disabled ? theme.textDisabled : theme.text,
+              fontSize: "12px",
+              textAlign: "left",
+              cursor: action.disabled ? "default" : "pointer",
+            }}
+            onMouseEnter={(e) => {
+              if (!action.disabled) {
+                (e.currentTarget as HTMLElement).style.background = theme.bgHover;
+              }
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "none";
+            }}
+          >
+            <span>{action.label}</span>
+            {action.shortcut && (
+              <span
+                style={{
+                  color: theme.textDisabled,
+                  fontSize: "11px",
+                  marginLeft: "24px",
+                }}
+              >
+                {action.shortcut}
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/app/frontend/src/components/Timeline.tsx
+++ b/app/frontend/src/components/Timeline.tsx
@@ -4,6 +4,7 @@ import { TimelineRuler } from "./TimelineRuler";
 import { TimelineTrack } from "./TimelineTrack";
 import { Playhead } from "./Playhead";
 import { ContextMenu } from "./ContextMenu";
+import type { MenuItem } from "./ContextMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { ClipKindPopup } from "./ClipKindPopup";
 import { useTimelineZoom } from "../hooks/useTimelineZoom";
@@ -345,61 +346,94 @@ export function Timeline({
         <ContextMenu
           position={{ x: contextMenu.x, y: contextMenu.y }}
           onClose={() => setContextMenu(null)}
-          items={[
-            ...(onCopyClip
-              ? [{
-                  label: "Copy (Ctrl+C)",
-                  onClick: () => {
-                    onSelectClip(contextMenu.clipId);
-                    onCopyClip();
-                  },
-                }]
-              : []),
-            ...(onPasteClip && hasClipboard
-              ? [{
-                  label: "Paste (Ctrl+V)",
-                  onClick: () => {
-                    onPasteClip();
-                  },
-                }]
-              : []),
-            ...(onDuplicateClip
-              ? [{
-                  label: "Duplicate (Ctrl+D)",
-                  onClick: () => {
-                    onSelectClip(contextMenu.clipId);
-                    onDuplicateClip();
-                  },
-                }]
-              : []),
-            ...(onPasteAttributes && hasClipboard
-              ? [{
-                  label: "Paste Attributes",
-                  onClick: () => {
-                    onSelectClip(contextMenu.clipId);
-                    onPasteAttributes();
-                  },
-                }]
-              : []),
-            {
+          items={(() => {
+            const items: MenuItem[] = [];
+
+            // Group 1: Split
+            if (onSplitClip) {
+              items.push({
+                label: "Split at Playhead",
+                shortcut: "S",
+                onClick: () => {
+                  onSplitClip(contextMenu.clipId, currentTimeMs);
+                },
+              });
+            }
+
+            // Separator between split and clipboard group
+            if (onSplitClip && (onCopyClip || onDuplicateClip)) {
+              items.push({ type: "separator" });
+            }
+
+            // Group 2: Clipboard operations
+            if (onCopyClip) {
+              items.push({
+                label: "Copy",
+                shortcut: "Ctrl+C",
+                onClick: () => {
+                  onSelectClip(contextMenu.clipId);
+                  onCopyClip();
+                },
+              });
+            }
+            if (onPasteClip) {
+              items.push({
+                label: "Paste",
+                shortcut: "Ctrl+V",
+                disabled: !hasClipboard,
+                onClick: () => {
+                  onPasteClip();
+                },
+              });
+            }
+            if (onDuplicateClip) {
+              items.push({
+                label: "Duplicate",
+                shortcut: "Ctrl+D",
+                onClick: () => {
+                  onSelectClip(contextMenu.clipId);
+                  onDuplicateClip();
+                },
+              });
+            }
+            if (onPasteAttributes) {
+              items.push({
+                label: "Paste Attributes",
+                disabled: !hasClipboard,
+                onClick: () => {
+                  onSelectClip(contextMenu.clipId);
+                  onPasteAttributes();
+                },
+              });
+            }
+
+            // Separator between clipboard and delete group
+            if (items.length > 0) {
+              items.push({ type: "separator" });
+            }
+
+            // Group 3: Delete operations
+            if (onRippleDeleteClip) {
+              items.push({
+                label: "Ripple Delete",
+                shortcut: "Shift+Del",
+                onClick: () => {
+                  onRippleDeleteClip(contextMenu.clipId);
+                  onSelectClip(null);
+                },
+              });
+            }
+            items.push({
               label: "Delete",
+              shortcut: "Del",
               onClick: () => {
                 onDeleteClip(contextMenu.clipId);
                 onSelectClip(null);
               },
-            },
-            ...(onRippleDeleteClip
-              ? [
-                  {
-                    label: "Ripple Delete (Shift+Del)",
-                    onClick: () => {
-                      onRippleDeleteClip(contextMenu.clipId);
-                      onSelectClip(null);
-                    },
-                  },
-                ]
-              : []),
-          ]}
+            });
+
+            return items;
+          })()}
         />
       )}
 

--- a/app/frontend/src/components/editors/index.ts
+++ b/app/frontend/src/components/editors/index.ts
@@ -1,37 +1,6 @@
-import { inspectorEditorRegistry } from "../../lib/inspector-editor-registry";
-import { TrimEditor } from "./TrimEditor";
-import { TextEditor } from "./TextEditor";
-import { TransformEditor } from "./TransformEditor";
-import { AudioVolumeEditor } from "./AudioVolumeEditor";
-
-inspectorEditorRegistry.register({
-  id: "trim",
-  label: "Trim",
-  order: 0,
-  canHandle: () => true,
-  Component: TrimEditor,
-});
-
-inspectorEditorRegistry.register({
-  id: "text",
-  label: "Text",
-  order: 10,
-  canHandle: (ctx) => ctx.clipKind === "title",
-  Component: TextEditor,
-});
-
-inspectorEditorRegistry.register({
-  id: "transform",
-  label: "Transform",
-  order: 20,
-  canHandle: (ctx) => ctx.clipKind === "video",
-  Component: TransformEditor,
-});
-
-inspectorEditorRegistry.register({
-  id: "audio-volume",
-  label: "Volume",
-  order: 30,
-  canHandle: (ctx) => ctx.clipKind === "audio",
-  Component: AudioVolumeEditor,
-});
+// Editor components are registered via builtin-plugin.ts.
+// This file is kept as a barrel export for direct imports if needed.
+export { TrimEditor } from "./TrimEditor";
+export { TextEditor } from "./TextEditor";
+export { TransformEditor } from "./TransformEditor";
+export { AudioVolumeEditor } from "./AudioVolumeEditor";


### PR DESCRIPTION
## Summary
- Context menu reorganized with separators and shortcut hints
- Split at Playhead, Copy, Paste, Duplicate, Paste Attributes, Ripple Delete, Delete
- Removed duplicate editor registrations from editors/index.ts

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)