### PR TITLE
Track Lock & Mute

### DIFF
--- a/app/backend/src/services/export-service.ts
+++ b/app/backend/src/services/export-service.ts
@@ -94,8 +94,10 @@ export function buildExportArgs(
   // Collect all visual clips from all tracks, with track index.
   // A clip is "visual" if a clip handler is registered for its asset kind.
   // Clips with empty assetId (no asset assigned) are skipped.
+  // Muted tracks are excluded from export.
   const allVisualClips: { clip: Clip; trackIndex: number }[] = [];
   project.sequence.tracks.forEach((track, trackIndex) => {
+    if (track.muted) return; // Skip muted tracks
     for (const clip of track.clips) {
       if (!clip.assetId) continue;
       const asset = project.assets.find((a) => a.id === clip.assetId);
@@ -260,23 +262,23 @@ export function buildExportArgs(
 
   let videoOut = currentBase;
 
-  // 4. Apply overlay handlers (text) - collect clips by clipKind from all tracks
+  // 4. Apply overlay handlers (text) - collect clips by clipKind from all tracks (skip muted)
   for (const overlayHandler of exportHandlerRegistry.getOverlayHandlers()) {
-    const matchingClips = project.sequence.tracks.flatMap((t) =>
-      t.clips.filter((c) => c.clipKind === overlayHandler.clipKind),
-    );
+    const matchingClips = project.sequence.tracks
+      .filter((t) => !t.muted)
+      .flatMap((t) => t.clips.filter((c) => c.clipKind === overlayHandler.clipKind));
     if (matchingClips.length > 0) {
       videoOut = overlayHandler.buildOverlay(matchingClips, ctx, videoOut);
     }
   }
 
-  // 5. Apply audio handlers - collect clips by clipKind from all tracks
+  // 5. Apply audio handlers - collect clips by clipKind from all tracks (skip muted)
   const allVideoClips = sortedClips.map(({ clip }) => clip);
   let audioFilter = "";
   for (const audioHandler of exportHandlerRegistry.getAudioHandlers()) {
-    const matchingClips = project.sequence.tracks.flatMap((t) =>
-      t.clips.filter((c) => c.clipKind === audioHandler.clipKind),
-    );
+    const matchingClips = project.sequence.tracks
+      .filter((t) => !t.muted)
+      .flatMap((t) => t.clips.filter((c) => c.clipKind === audioHandler.clipKind));
     const result = audioHandler.buildAudio(matchingClips, ctx, allVideoClips);
     if (result) {
       audioFilter = result;
@@ -331,8 +333,8 @@ export async function startExport(
   const outputPath = path.join(expDir, path.basename(filename));
   const assetsBase = assetsDir(projectId);
 
-  // Validate - check for visual clips across all tracks (skip empty-asset clips)
-  const visualClips = project.sequence.tracks.flatMap((t) =>
+  // Validate - check for visual clips across non-muted tracks (skip empty-asset clips)
+  const visualClips = project.sequence.tracks.filter((t) => !t.muted).flatMap((t) =>
     t.clips.filter((c) => {
       if (!c.assetId) return false;
       const asset = project.assets.find((a) => a.id === c.assetId);

--- a/app/frontend/src/components/Timeline.tsx
+++ b/app/frontend/src/components/Timeline.tsx
@@ -38,6 +38,8 @@ type Props = {
   hasClipboard?: boolean;
   snapEnabled?: boolean;
   onToggleSnap?: () => void;
+  onToggleTrackLocked?: (trackId: string, locked: boolean) => void;
+  onToggleTrackMuted?: (trackId: string, muted: boolean) => void;
 };
 
 function getTimelineDuration(project: Project): number {
@@ -68,6 +70,8 @@ export function Timeline({
   hasClipboard,
   snapEnabled = true,
   onToggleSnap,
+  onToggleTrackLocked,
+  onToggleTrackMuted,
 }: Props) {
   const { msToPx, pxToMs, zoomIn, zoomOut } = useTimelineZoom();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -345,6 +349,8 @@ export function Timeline({
                   onTrackDoubleClick={handleTrackDoubleClick}
                   onSplitClip={onSplitClip}
                   toolMode={toolMode}
+                  onToggleLocked={onToggleTrackLocked}
+                  onToggleMuted={onToggleTrackMuted}
                 />
               ))
             )}
@@ -524,15 +530,37 @@ export function Timeline({
         <ContextMenu
           position={{ x: trackContextMenu.x, y: trackContextMenu.y }}
           onClose={() => setTrackContextMenu(null)}
-          items={[
-            {
+          items={(() => {
+            const trk = project.sequence.tracks.find((t: Track) => t.id === trackContextMenu.trackId);
+            const items: MenuItem[] = [];
+            if (onToggleTrackLocked) {
+              items.push({
+                label: trk?.locked ? "Unlock Track" : "Lock Track",
+                onClick: () => {
+                  onToggleTrackLocked(trackContextMenu.trackId, !trk?.locked);
+                },
+              });
+            }
+            if (onToggleTrackMuted) {
+              items.push({
+                label: trk?.muted ? "Unmute Track" : "Mute Track",
+                onClick: () => {
+                  onToggleTrackMuted(trackContextMenu.trackId, !trk?.muted);
+                },
+              });
+            }
+            if (items.length > 0) {
+              items.push({ type: "separator" });
+            }
+            items.push({
               label: "Delete Track",
               onClick: () => {
                 setConfirmDeleteTrackId(trackContextMenu.trackId);
                 setTrackContextMenu(null);
               },
-            },
-          ]}
+            });
+            return items;
+          })()}
         />
       )}
 

--- a/app/frontend/src/components/TimelineClip.tsx
+++ b/app/frontend/src/components/TimelineClip.tsx
@@ -20,6 +20,7 @@ type Props = {
   onDragTrackChange?: (targetTrackId: string | null) => void;
   onSplitClip?: (clipId: string, splitTimeMs: number) => void;
   toolMode?: "select" | "razor";
+  isLocked?: boolean;
 };
 
 const TRIM_HANDLE_WIDTH = 6;
@@ -49,6 +50,7 @@ export function TimelineClip({
   onDragTrackChange,
   onSplitClip,
   toolMode = "select",
+  isLocked = false,
 }: Props) {
   const width = msToPx(clip.durationMs);
   const left = msToPx(clip.startMs);
@@ -96,11 +98,13 @@ export function TimelineClip({
       e.preventDefault();
 
       if (toolMode === "razor") {
+        if (isLocked) return;
         handleRazorClick(e);
         return;
       }
 
       onSelect(clip.id, { shiftKey: e.shiftKey });
+      if (isLocked) return;
       const sourceTrackIndex = allTrackIds.indexOf(trackId);
       dragRef.current = { startX: e.clientX, startMs: clip.startMs, startY: e.clientY, sourceTrackIndex };
       setIsDragging(true);
@@ -156,7 +160,7 @@ export function TimelineClip({
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [clip.id, clip.startMs, clip.durationMs, pxToMs, onSelect, onMove, maxDurationMs, trackId, allTrackIds, onDragTrackChange, toolMode, handleRazorClick],
+    [clip.id, clip.startMs, clip.durationMs, pxToMs, onSelect, onMove, maxDurationMs, trackId, allTrackIds, onDragTrackChange, toolMode, handleRazorClick, isLocked],
   );
 
   const formatTrimLabel = useCallback(
@@ -171,6 +175,7 @@ export function TimelineClip({
     (side: "left" | "right", e: React.MouseEvent) => {
       e.stopPropagation();
       e.preventDefault();
+      if (isLocked) return;
       onSelect(clip.id);
       trimRef.current = { startX: e.clientX, side };
       setTrimTooltip({ side, label: formatTrimLabel(side) });
@@ -199,7 +204,7 @@ export function TimelineClip({
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [clip.id, pxToMs, onSelect, onTrim, onRippleTrim, formatTrimLabel],
+    [clip.id, pxToMs, onSelect, onTrim, onRippleTrim, formatTrimLabel, isLocked],
   );
 
   // Update tooltip value during trim drag
@@ -229,7 +234,7 @@ export function TimelineClip({
         borderRadius: "3px",
         border: `${isSelected ? 2 : 1}px ${isEmptyAsset ? "dashed" : "solid"} ${borderColor}`,
         overflow: "hidden",
-        cursor: toolMode === "razor" ? "crosshair" : isDragging ? "grabbing" : "grab",
+        cursor: isLocked ? "not-allowed" : toolMode === "razor" ? "crosshair" : isDragging ? "grabbing" : "grab",
         opacity: isDraggingToOtherTrack ? 0.5 : 1,
         display: "flex",
         alignItems: "center",

--- a/app/frontend/src/components/TimelineTrack.tsx
+++ b/app/frontend/src/components/TimelineTrack.tsx
@@ -26,6 +26,8 @@ type Props = {
   onTrackDoubleClick?: (trackId: string, timeMs: number, position: { x: number; y: number }) => void;
   onSplitClip?: (clipId: string, splitTimeMs: number) => void;
   toolMode?: "select" | "razor";
+  onToggleLocked?: (trackId: string, locked: boolean) => void;
+  onToggleMuted?: (trackId: string, muted: boolean) => void;
 };
 
 export function TimelineTrack({
@@ -50,12 +52,17 @@ export function TimelineTrack({
   onTrackDoubleClick,
   onSplitClip,
   toolMode = "select",
+  onToggleLocked,
+  onToggleMuted,
 }: Props) {
   const assetMap = new Map(assets.map((a) => [a.id, a]));
   const sortedClips = useMemo(
     () => [...track.clips].sort((a, b) => a.startMs - b.startMs),
     [track.clips],
   );
+
+  const isLocked = track.locked === true;
+  const isMuted = track.muted === true;
 
   return (
     <div style={{ display: "flex", height: "40px" }}>
@@ -69,6 +76,7 @@ export function TimelineTrack({
           width: "32px",
           flexShrink: 0,
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           background: theme.bgHover,
@@ -77,9 +85,52 @@ export function TimelineTrack({
           fontSize: "11px",
           fontWeight: "bold",
           userSelect: "none",
+          gap: "1px",
         }}
       >
-        {trackIndex + 1}
+        <span style={{ fontSize: "9px", lineHeight: 1 }}>{trackIndex + 1}</span>
+        <div style={{ display: "flex", gap: "1px" }}>
+          <button
+            title={isLocked ? "Unlock track" : "Lock track"}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleLocked?.(track.id, !isLocked);
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              fontSize: "10px",
+              lineHeight: 1,
+              color: isLocked ? theme.warning : theme.textMuted,
+              opacity: isLocked ? 1 : 0.5,
+            }}
+          >
+            {isLocked ? "\uD83D\uDD12" : "\uD83D\uDD13"}
+          </button>
+          <button
+            title={isMuted ? "Unmute track" : "Mute track"}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleMuted?.(track.id, !isMuted);
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              fontSize: "10px",
+              lineHeight: 1,
+              color: isMuted ? theme.error : theme.textMuted,
+              opacity: isMuted ? 1 : 0.5,
+            }}
+          >
+            {isMuted ? "\uD83D\uDD07" : "\uD83D\uDD0A"}
+          </button>
+        </div>
       </div>
       <div
         onMouseDown={(e) => {
@@ -101,7 +152,8 @@ export function TimelineTrack({
           minWidth: `${totalWidth}px`,
           background: isDropTarget ? theme.bgHover : theme.timelineTrackBg,
           borderBottom: `1px solid ${theme.borderLight}`,
-          transition: "background 0.1s",
+          transition: "background 0.1s, opacity 0.15s",
+          opacity: isMuted ? 0.4 : isLocked ? 0.7 : 1,
         }}
       >
         {track.clips.map((clip: Clip) => (
@@ -123,6 +175,7 @@ export function TimelineTrack({
             onDragTrackChange={onDragTrackChange}
             onSplitClip={onSplitClip}
             toolMode={toolMode}
+            isLocked={isLocked}
           />
         ))}
 

--- a/app/frontend/src/components/renderers/TextOverlayRenderer.tsx
+++ b/app/frontend/src/components/renderers/TextOverlayRenderer.tsx
@@ -3,6 +3,7 @@ import type { ActiveTextClip, PreviewRenderContext, PreviewLayerRenderer } from 
 function findActiveTextClips(ctx: PreviewRenderContext): ActiveTextClip[] | null {
   const result: ActiveTextClip[] = [];
   for (const track of ctx.project.sequence.tracks) {
+    if (track.muted) continue; // Skip muted tracks in preview
     for (const clip of track.clips) {
       if (clip.clipKind !== "title") continue;
       if (ctx.currentTimeMs >= clip.startMs && ctx.currentTimeMs < clip.startMs + clip.durationMs && clip.text) {

--- a/app/frontend/src/hooks/useProjectEditor.ts
+++ b/app/frontend/src/hooks/useProjectEditor.ts
@@ -168,6 +168,20 @@ export function useProjectEditor(
     [sequence, pushState],
   );
 
+  const setTrackLocked = useCallback(
+    (trackId: string, locked: boolean) => {
+      pushState(SeqOps.setTrackLocked(sequence, trackId, locked));
+    },
+    [sequence, pushState],
+  );
+
+  const setTrackMuted = useCallback(
+    (trackId: string, muted: boolean) => {
+      pushState(SeqOps.setTrackMuted(sequence, trackId, muted));
+    },
+    [sequence, pushState],
+  );
+
   return {
     addClipFromAsset,
     removeClip,
@@ -187,5 +201,7 @@ export function useProjectEditor(
     moveClips,
     groupClips,
     ungroupClips,
+    setTrackLocked,
+    setTrackMuted,
   };
 }

--- a/app/frontend/src/lib/__snapshots__/sequence-ops.regression.test.ts.snap
+++ b/app/frontend/src/lib/__snapshots__/sequence-ops.regression.test.ts.snap
@@ -1717,3 +1717,127 @@ exports[`editor operation regression group: groupClips assigns groupId, ungroupC
   ],
 }
 `;
+
+exports[`track lock & mute regression setTrackLocked then attempt operations 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 5000,
+        },
+      ],
+      "id": "track-0",
+      "locked": true,
+    },
+  ],
+}
+`;
+
+exports[`track lock & mute regression setTrackLocked then attempt operations 2`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 5000,
+        },
+      ],
+      "id": "track-0",
+      "locked": false,
+    },
+  ],
+}
+`;
+
+exports[`track lock & mute regression setTrackMuted preserves track state 1`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "i1",
+          "clipKind": "image",
+          "durationMs": 3000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 5000,
+        },
+      ],
+      "id": "track-0",
+      "muted": true,
+    },
+  ],
+}
+`;
+
+exports[`track lock & mute regression setTrackMuted preserves track state 2`] = `
+{
+  "tracks": [
+    {
+      "clips": [
+        {
+          "assetId": "v1",
+          "clipKind": "video",
+          "durationMs": 5000,
+          "id": "clip-0",
+          "inMs": 0,
+          "outMs": 5000,
+          "startMs": 0,
+        },
+        {
+          "assetId": "i1",
+          "clipKind": "image",
+          "durationMs": 3000,
+          "id": "clip-1",
+          "inMs": 0,
+          "outMs": 3000,
+          "startMs": 5000,
+        },
+      ],
+      "id": "track-0",
+      "muted": false,
+    },
+  ],
+}
+`;

--- a/app/frontend/src/lib/preview-renderer-registry.ts
+++ b/app/frontend/src/lib/preview-renderer-registry.ts
@@ -81,6 +81,7 @@ export function findActiveClipInTracks(
 ): ActiveClip | null {
   for (let i = 0; i < project.sequence.tracks.length; i++) {
     const track = project.sequence.tracks[i];
+    if (track.muted) continue; // Skip muted tracks in preview
     for (const clip of track.clips) {
       if (clip.clipKind !== clipKind) continue;
       if (isEmptyAssetClip(clip)) continue;
@@ -107,6 +108,7 @@ export function findAllActiveClips(
   const result: ActiveClip[] = [];
   for (let i = 0; i < project.sequence.tracks.length; i++) {
     const track = project.sequence.tracks[i];
+    if (track.muted) continue; // Skip muted tracks in preview
     for (const clip of track.clips) {
       if (clipKind && clip.clipKind !== clipKind) continue;
       if (isEmptyAssetClip(clip)) continue;
@@ -137,6 +139,7 @@ export function findAllActiveEmptyClips(
   const result: ActiveEmptyClip[] = [];
   for (let i = 0; i < project.sequence.tracks.length; i++) {
     const track = project.sequence.tracks[i];
+    if (track.muted) continue; // Skip muted tracks in preview
     for (const clip of track.clips) {
       if (!isEmptyAssetClip(clip)) continue;
       // title clips with text are handled by the text overlay renderer

--- a/app/frontend/src/lib/sequence-ops.regression.test.ts
+++ b/app/frontend/src/lib/sequence-ops.regression.test.ts
@@ -23,6 +23,8 @@ import {
   moveClips,
   groupClips,
   ungroupClips,
+  setTrackLocked,
+  setTrackMuted,
 } from "./sequence-ops";
 
 const videoAsset: Asset = {
@@ -990,5 +992,62 @@ describe("editor operation regression", () => {
 
     seq = ungroupClips(seq, clipIds);
     expect(stabilize(seq)).toMatchSnapshot();
+  });
+});
+
+describe("track lock & mute regression", () => {
+  test("setTrackLocked then attempt operations", () => {
+    let seq: Sequence = { tracks: [] };
+    seq = addClipFromAsset(seq, videoAsset, 30000);
+    seq = addClipFromAsset(seq, videoAsset, 30000);
+
+    // Lock the track
+    const trackId = seq.tracks[0].id;
+    seq = setTrackLocked(seq, trackId, true);
+    expect(stabilize(seq)).toMatchSnapshot();
+
+    // Attempt move on locked track — should be unchanged
+    const clipId = seq.tracks[0].clips[0].id;
+    const afterMove = moveClip(seq, clipId, 1000, 30000);
+    expect(afterMove).toBe(seq);
+
+    // Unlock and move should work
+    seq = setTrackLocked(seq, trackId, false);
+    const afterUnlock = moveClip(seq, seq.tracks[0].clips[0].id, 1000, 30000);
+    expect(stabilize(afterUnlock)).toMatchSnapshot();
+  });
+
+  test("setTrackMuted preserves track state", () => {
+    let seq: Sequence = { tracks: [] };
+    seq = addClipFromAsset(seq, videoAsset, 30000);
+    seq = addClipFromAsset(seq, imageAsset, 30000);
+
+    const trackId = seq.tracks[0].id;
+    seq = setTrackMuted(seq, trackId, true);
+    expect(stabilize(seq)).toMatchSnapshot();
+
+    seq = setTrackMuted(seq, trackId, false);
+    expect(stabilize(seq)).toMatchSnapshot();
+  });
+
+  test("locked track blocks addClipFromAsset to that track", () => {
+    let seq: Sequence = { tracks: [] };
+    seq = addClipFromAsset(seq, videoAsset, 30000);
+    const trackId = seq.tracks[0].id;
+    seq = setTrackLocked(seq, trackId, true);
+
+    const afterAdd = addClipFromAsset(seq, videoAsset, 30000, trackId);
+    expect(afterAdd).toBe(seq);
+  });
+
+  test("locked track blocks splitClip", () => {
+    let seq: Sequence = { tracks: [] };
+    seq = addClipFromAsset(seq, videoAsset, 30000);
+    const trackId = seq.tracks[0].id;
+    const clipId = seq.tracks[0].clips[0].id;
+    seq = setTrackLocked(seq, trackId, true);
+
+    const afterSplit = splitClip(seq, clipId, 2500);
+    expect(afterSplit).toBe(seq);
   });
 });

--- a/app/frontend/src/lib/sequence-ops.test.ts
+++ b/app/frontend/src/lib/sequence-ops.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import type { Asset, Clip, Sequence, Track } from "@video/shared";
 import { inferTrackKind } from "@video/shared";
-import { addClipFromAsset, removeClip, moveClip, trimClip, addTextClip, updateClip, findNonOverlappingPosition, clampClipsToDuration, removeTrack, setTransition, removeTransition, splitClip, rippleDelete, rippleTrim, duplicateClip, pasteClip, pasteAttributes, removeClips, moveClips, groupClips, ungroupClips, expandGroupSelection } from "./sequence-ops";
+import { addClipFromAsset, removeClip, moveClip, trimClip, addTextClip, updateClip, findNonOverlappingPosition, clampClipsToDuration, removeTrack, setTransition, removeTransition, splitClip, rippleDelete, rippleTrim, duplicateClip, pasteClip, pasteAttributes, removeClips, moveClips, groupClips, ungroupClips, expandGroupSelection, setTrackLocked, setTrackMuted, isClipOnLockedTrack, areAnyClipsOnLockedTrack } from "./sequence-ops";
 
 const emptySeq: Sequence = { tracks: [] };
 
@@ -1468,5 +1468,162 @@ describe("expandGroupSelection", () => {
     const expanded = expandGroupSelection(grouped, new Set(["c2"]));
     expect(expanded.size).toBe(1);
     expect(expanded.has("c2")).toBe(true);
+  });
+});
+
+// ────────── Track Lock & Mute ──────────
+
+describe("setTrackLocked / setTrackMuted", () => {
+  const baseTracks: Track[] = [
+    { id: "t1", clips: [{ id: "c1", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 2000, inMs: 0, outMs: 2000 }] },
+    { id: "t2", clips: [{ id: "c2", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 3000, inMs: 0, outMs: 3000 }] },
+  ];
+  const seq: Sequence = { tracks: baseTracks };
+
+  test("setTrackLocked sets locked=true", () => {
+    const result = setTrackLocked(seq, "t1", true);
+    expect(result.tracks[0].locked).toBe(true);
+    expect(result.tracks[1].locked).toBeUndefined();
+  });
+
+  test("setTrackLocked sets locked=false", () => {
+    const locked = setTrackLocked(seq, "t1", true);
+    const unlocked = setTrackLocked(locked, "t1", false);
+    expect(unlocked.tracks[0].locked).toBe(false);
+  });
+
+  test("setTrackMuted sets muted=true", () => {
+    const result = setTrackMuted(seq, "t2", true);
+    expect(result.tracks[1].muted).toBe(true);
+    expect(result.tracks[0].muted).toBeUndefined();
+  });
+
+  test("setTrackMuted sets muted=false", () => {
+    const muted = setTrackMuted(seq, "t2", true);
+    const unmuted = setTrackMuted(muted, "t2", false);
+    expect(unmuted.tracks[1].muted).toBe(false);
+  });
+});
+
+describe("isClipOnLockedTrack / areAnyClipsOnLockedTrack", () => {
+  const baseTracks: Track[] = [
+    { id: "t1", clips: [{ id: "c1", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 2000, inMs: 0, outMs: 2000 }], locked: true },
+    { id: "t2", clips: [{ id: "c2", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 3000, inMs: 0, outMs: 3000 }] },
+  ];
+  const seq: Sequence = { tracks: baseTracks };
+
+  test("isClipOnLockedTrack returns true for clip on locked track", () => {
+    expect(isClipOnLockedTrack(seq, "c1")).toBe(true);
+  });
+
+  test("isClipOnLockedTrack returns false for clip on unlocked track", () => {
+    expect(isClipOnLockedTrack(seq, "c2")).toBe(false);
+  });
+
+  test("areAnyClipsOnLockedTrack returns true if any clip is on locked track", () => {
+    expect(areAnyClipsOnLockedTrack(seq, new Set(["c1", "c2"]))).toBe(true);
+  });
+
+  test("areAnyClipsOnLockedTrack returns false if no clips on locked track", () => {
+    expect(areAnyClipsOnLockedTrack(seq, new Set(["c2"]))).toBe(false);
+  });
+});
+
+describe("locked track prevents editing operations", () => {
+  const lockedTrack: Track = {
+    id: "t1",
+    clips: [
+      { id: "c1", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 2000, inMs: 0, outMs: 2000 },
+      { id: "c2", clipKind: "video", assetId: "v1", startMs: 2000, durationMs: 2000, inMs: 0, outMs: 2000 },
+    ],
+    locked: true,
+  };
+  const unlockedTrack: Track = {
+    id: "t2",
+    clips: [
+      { id: "c3", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 3000, inMs: 0, outMs: 3000 },
+    ],
+  };
+  const seq: Sequence = { tracks: [lockedTrack, unlockedTrack] };
+
+  test("removeClip returns unchanged sequence for locked track clip", () => {
+    const result = removeClip(seq, "c1");
+    expect(result).toBe(seq);
+  });
+
+  test("removeClip works for unlocked track clip", () => {
+    const result = removeClip(seq, "c3");
+    expect(result.tracks.length).toBe(1); // unlocked track removed (empty)
+  });
+
+  test("moveClip returns unchanged sequence for locked track clip", () => {
+    const result = moveClip(seq, "c1", 1000);
+    expect(result).toBe(seq);
+  });
+
+  test("moveClip rejects cross-track move to locked track", () => {
+    const result = moveClip(seq, "c3", 5000, undefined, "t1");
+    expect(result).toBe(seq);
+  });
+
+  test("trimClip returns unchanged sequence for locked track clip", () => {
+    const result = trimClip(seq, "c1", "right", 500);
+    expect(result).toBe(seq);
+  });
+
+  test("splitClip returns unchanged sequence for locked track clip", () => {
+    const result = splitClip(seq, "c1", 1000);
+    expect(result).toBe(seq);
+  });
+
+  test("updateClip returns unchanged sequence for locked track clip", () => {
+    const result = updateClip(seq, "c1", { durationMs: 5000 });
+    expect(result).toBe(seq);
+  });
+
+  test("removeClips returns unchanged sequence when any clip is on locked track", () => {
+    const result = removeClips(seq, new Set(["c1", "c3"]));
+    expect(result).toBe(seq);
+  });
+
+  test("moveClips returns unchanged sequence when any clip is on locked track", () => {
+    const result = moveClips(seq, new Set(["c1"]), 500);
+    expect(result).toBe(seq);
+  });
+
+  test("rippleDelete returns unchanged sequence for locked track clip", () => {
+    const result = rippleDelete(seq, "c1");
+    expect(result).toBe(seq);
+  });
+
+  test("rippleTrim returns unchanged sequence for locked track clip", () => {
+    const result = rippleTrim(seq, "c1", "right", 500);
+    expect(result).toBe(seq);
+  });
+
+  test("duplicateClip returns unchanged sequence for locked track clip", () => {
+    const result = duplicateClip(seq, "c1", 30000);
+    expect(result).toBe(seq);
+  });
+
+  test("pasteClip rejects paste to locked track", () => {
+    const clipToPaste: Clip = { id: "cx", clipKind: "video", assetId: "v1", startMs: 0, durationMs: 1000, inMs: 0, outMs: 1000 };
+    const result = pasteClip(seq, clipToPaste, 5000, "t1", 30000);
+    expect(result).toBe(seq);
+  });
+
+  test("setTransition returns unchanged sequence for locked track clip", () => {
+    const result = setTransition(seq, "c2", { type: "fade", durationMs: 500 });
+    expect(result).toBe(seq);
+  });
+
+  test("addClipFromAsset rejects adding to locked track", () => {
+    const result = addClipFromAsset(seq, videoAsset, 30000, "t1");
+    expect(result).toBe(seq);
+  });
+
+  test("addTextClip rejects adding to locked track", () => {
+    const result = addTextClip(seq, 0, 2000, { value: "Test" }, 30000, "t1");
+    expect(result).toBe(seq);
   });
 });

--- a/app/frontend/src/lib/sequence-ops.ts
+++ b/app/frontend/src/lib/sequence-ops.ts
@@ -37,6 +37,7 @@ export function expandGroupSelection(
  * Empty tracks are removed.
  */
 export function removeClips(sequence: Sequence, clipIds: ReadonlySet<string>): Sequence {
+  if (areAnyClipsOnLockedTrack(sequence, clipIds)) return sequence;
   const tracks = sequence.tracks
     .map((track: Track) => ({
       ...track,
@@ -56,6 +57,7 @@ export function moveClips(
   deltaMs: number,
   maxDurationMs?: number,
 ): Sequence {
+  if (areAnyClipsOnLockedTrack(sequence, clipIds)) return sequence;
   // Find minimum startMs among selected clips to prevent going below 0
   let minStart = Infinity;
   let maxEnd = 0;
@@ -127,6 +129,11 @@ export function addClipFromAsset(
   maxDurationMs?: number,
   targetTrackId?: string,
 ): Sequence {
+  // Reject if target track is locked
+  if (targetTrackId) {
+    const target = sequence.tracks.find((t: Track) => t.id === targetTrackId);
+    if (target?.locked) return sequence;
+  }
   const tracks = sequence.tracks.map((t: Track) => ({ ...t, clips: [...t.clips] }));
   const descriptor = assetKindRegistry.get(asset.kind);
   let track: Track | undefined;
@@ -177,6 +184,7 @@ export function addClipFromAsset(
 }
 
 export function removeClip(sequence: Sequence, clipId: string): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   const tracks = sequence.tracks
     .map((track: Track) => ({
       ...track,
@@ -256,6 +264,12 @@ export function moveClip(
   maxDurationMs?: number,
   targetTrackId?: string,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
+  // Also reject if target track is locked
+  if (targetTrackId) {
+    const target = sequence.tracks.find((t: Track) => t.id === targetTrackId);
+    if (target?.locked) return sequence;
+  }
   let startMs = Math.max(0, Math.round(newStartMs));
 
   // Find the clip and its source track
@@ -335,6 +349,50 @@ export function removeTrack(sequence: Sequence, trackId: string): Sequence {
   return { ...sequence, tracks };
 }
 
+/**
+ * Set the locked state of a track.
+ */
+export function setTrackLocked(sequence: Sequence, trackId: string, locked: boolean): Sequence {
+  const tracks = sequence.tracks.map((t: Track) =>
+    t.id === trackId ? { ...t, locked } : t,
+  );
+  return { ...sequence, tracks };
+}
+
+/**
+ * Set the muted state of a track.
+ */
+export function setTrackMuted(sequence: Sequence, trackId: string, muted: boolean): Sequence {
+  const tracks = sequence.tracks.map((t: Track) =>
+    t.id === trackId ? { ...t, muted } : t,
+  );
+  return { ...sequence, tracks };
+}
+
+/**
+ * Check if a clip belongs to a locked track.
+ */
+export function isClipOnLockedTrack(sequence: Sequence, clipId: string): boolean {
+  for (const track of sequence.tracks) {
+    if (track.clips.some((c: Clip) => c.id === clipId)) {
+      return track.locked === true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if any of the given clip IDs are on a locked track.
+ */
+export function areAnyClipsOnLockedTrack(sequence: Sequence, clipIds: ReadonlySet<string>): boolean {
+  for (const track of sequence.tracks) {
+    if (track.locked && track.clips.some((c: Clip) => clipIds.has(c.id))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function addTextClip(
   sequence: Sequence,
   startMs: number,
@@ -343,6 +401,11 @@ export function addTextClip(
   maxDurationMs?: number,
   targetTrackId?: string,
 ): Sequence {
+  // Reject if target track is locked
+  if (targetTrackId) {
+    const target = sequence.tracks.find((t: Track) => t.id === targetTrackId);
+    if (target?.locked) return sequence;
+  }
   // Reject if start is beyond the limit
   if (maxDurationMs != null && startMs >= maxDurationMs) {
     return sequence;
@@ -389,6 +452,11 @@ export function addEmptyClip(
   targetTrackId?: string,
   text?: ClipText,
 ): Sequence {
+  // Reject if target track is locked
+  if (targetTrackId) {
+    const target = sequence.tracks.find((t: Track) => t.id === targetTrackId);
+    if (target?.locked) return sequence;
+  }
   // Reject if start is beyond the limit
   if (maxDurationMs != null && startMs >= maxDurationMs) {
     return sequence;
@@ -463,6 +531,7 @@ export function updateClip(
   clipId: string,
   updates: Partial<Clip>,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   const tracks = sequence.tracks.map((track: Track) => ({
     ...track,
     clips: track.clips.map((c: Clip) =>
@@ -482,6 +551,7 @@ export function setTransition(
   clipId: string,
   transition: ClipTransition,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   // Find the clip and its track
   let targetTrack: Track | undefined;
   let clipIdx = -1;
@@ -531,6 +601,7 @@ export function removeTransition(
   sequence: Sequence,
   clipId: string,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   let targetTrack: Track | undefined;
   for (const track of sequence.tracks) {
     if (track.clips.some((c) => c.id === clipId)) {
@@ -561,6 +632,7 @@ export function splitClip(
   clipId: string,
   splitTimeMs: number,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   // Find the clip and its track
   let targetTrack: Track | undefined;
   let clipIdx = -1;
@@ -620,6 +692,7 @@ export function splitClip(
  * to fill the gap. If the track becomes empty, remove it.
  */
 export function rippleDelete(sequence: Sequence, clipId: string): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   // Find the clip and its track
   let targetTrack: Track | undefined;
   let targetClip: Clip | undefined;
@@ -676,6 +749,7 @@ export function rippleTrim(
   maxSourceDurationMs?: number,
   maxTimelineDurationMs?: number,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   // Find the clip before trimming
   let oldClip: Clip | undefined;
   let trackId: string | undefined;
@@ -739,6 +813,7 @@ export function duplicateClip(
   clipId: string,
   maxDurationMs: number,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   let targetTrack: Track | undefined;
   let originalClip: Clip | undefined;
   for (const track of sequence.tracks) {
@@ -799,6 +874,9 @@ export function pasteClip(
   targetTrackId: string,
   maxDurationMs: number,
 ): Sequence {
+  // Reject if target track is locked
+  const targetCheck = sequence.tracks.find((t: Track) => t.id === targetTrackId);
+  if (targetCheck?.locked) return sequence;
   const startMs = Math.max(0, Math.round(pasteTimeMs));
 
   // Reject if start is beyond the limit
@@ -870,6 +948,7 @@ export function trimClip(
   maxSourceDurationMs?: number,
   maxTimelineDurationMs?: number,
 ): Sequence {
+  if (isClipOnLockedTrack(sequence, clipId)) return sequence;
   const tracks = sequence.tracks.map((track: Track) => ({
     ...track,
     clips: track.clips.map((c: Clip) => {

--- a/app/frontend/src/pages/EditorPage.tsx
+++ b/app/frontend/src/pages/EditorPage.tsx
@@ -110,7 +110,7 @@ function EditorPageLoaded({
     project.sequence,
   );
 
-  const { addClipFromAsset, removeClip, moveClip, trimClip, splitClip, addTextClip, addEmptyClip, updateClip, setTransition, rippleDelete, rippleTrim, duplicateClip, pasteClip, pasteAttributes, removeClips, groupClips, ungroupClips } =
+  const { addClipFromAsset, removeClip, moveClip, trimClip, splitClip, addTextClip, addEmptyClip, updateClip, setTransition, rippleDelete, rippleTrim, duplicateClip, pasteClip, pasteAttributes, removeClips, groupClips, ungroupClips, setTrackLocked, setTrackMuted } =
     useProjectEditor(project, sequence, pushState);
 
   // Primary selected clip (first in the set) — used for inspector, preview, etc.
@@ -582,6 +582,8 @@ function EditorPageLoaded({
           hasClipboard={clipboardClip !== null}
           snapEnabled={snapEnabled}
           onToggleSnap={toggleSnap}
+          onToggleTrackLocked={setTrackLocked}
+          onToggleTrackMuted={setTrackMuted}
         />
       }
     />


### PR DESCRIPTION
## Summary
- Lock tracks to prevent editing, mute to exclude from preview/export
- Lock/mute icons in track header, visual dimming
- 19 unit tests + 4 snapshot regression tests

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)