### PR TITLE
Add Web Audio API audio mixing to Canvas export

### DIFF
--- a/app/frontend/src/components/CanvasExportPanel.tsx
+++ b/app/frontend/src/components/CanvasExportPanel.tsx
@@ -162,6 +162,33 @@ export function CanvasExportPanel({ project }: Props) {
     [project.assets, getVideoFrame, getImageFrame],
   );
 
+  /**
+   * Resolve an asset ID to a fetchable audio URL (for audio clips and
+   * video clips with embedded audio).
+   */
+  const getAudioUrl = useCallback(
+    (assetId: string): string | null => {
+      const asset = project.assets.find((a) => a.id === assetId);
+      if (!asset) return null;
+
+      if (asset.kind === "audio") {
+        if (asset.originalPath) {
+          const filename = asset.originalPath.split("/").pop();
+          return `/media/projects/${project.id}/originals/${filename}`;
+        }
+        return null;
+      }
+
+      if (asset.kind === "video" && asset.hasAudio) {
+        const url = getMediaUrl(asset, project.id);
+        return url || null;
+      }
+
+      return null;
+    },
+    [project.assets, project.id],
+  );
+
   const useWorker = isWorkerExportSupported();
 
   const handleExport = useCallback(async () => {
@@ -173,6 +200,7 @@ export function CanvasExportPanel({ project }: Props) {
       const result = await exportFn({
         project,
         getFrameSource,
+        getAudioUrl,
         onProgress: (progress) => {
           setState({ status: "exporting", progress });
         },
@@ -190,7 +218,7 @@ export function CanvasExportPanel({ project }: Props) {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [project, getFrameSource, useWorker]);
+  }, [project, getFrameSource, getAudioUrl, useWorker]);
 
   const handleDownload = useCallback(() => {
     if (state.status !== "completed") return;
@@ -243,8 +271,8 @@ export function CanvasExportPanel({ project }: Props) {
           fontSize: "11px",
         }}
       >
-        Export video directly in the browser using WebCodecs (video only, no
-        audio).{useWorker ? " Encoding runs in a background worker." : ""}
+        Export video with audio directly in the browser using WebCodecs.
+        {useWorker ? " Encoding runs in a background worker." : ""}
       </div>
 
       {state.status === "idle" && (

--- a/app/frontend/src/lib/audio-mixer.ts
+++ b/app/frontend/src/lib/audio-mixer.ts
@@ -1,0 +1,240 @@
+/**
+ * Offline audio mixer using Web Audio API's OfflineAudioContext.
+ *
+ * Collects audio clips (clipKind === "audio") and video clips with embedded
+ * audio (asset.hasAudio === true) from non-muted tracks, fetches and decodes
+ * each audio file, mixes them down via gain-scheduled AudioBufferSourceNodes,
+ * and returns a single mixed AudioBuffer ready for mediabunny encoding.
+ */
+
+import type { Project, Asset, Clip, KeyframeTrack } from "@video/shared";
+
+// ── Public types ──
+
+export type AudioMixOptions = {
+  project: Project;
+  /** Resolve an asset ID to a fetchable audio URL, or null to skip. */
+  getAudioUrl: (assetId: string) => string | null;
+  /** Sample rate for the mixed output (default 48000). */
+  sampleRate?: number;
+  /** Progress callback (0..1). */
+  onProgress?: (progress: number) => void;
+};
+
+export type AudioMixResult = {
+  audioBuffer: AudioBuffer;
+  sampleRate: number;
+  durationMs: number;
+};
+
+// ── Internals ──
+
+type AudioClipInfo = {
+  clip: Clip;
+  asset: Asset;
+  url: string;
+};
+
+/**
+ * Collect all clips that contribute audio from non-muted tracks.
+ */
+function collectAudioClips(project: Project, getAudioUrl: (assetId: string) => string | null): AudioClipInfo[] {
+  const result: AudioClipInfo[] = [];
+
+  for (const track of project.sequence.tracks) {
+    if (track.muted) continue;
+
+    for (const clip of track.clips) {
+      const asset = project.assets.find((a) => a.id === clip.assetId);
+      if (!asset) continue;
+
+      const isAudioClip = clip.clipKind === "audio";
+      const isVideoWithAudio = clip.clipKind === "video" && asset.hasAudio === true;
+
+      if (!isAudioClip && !isVideoWithAudio) continue;
+
+      const url = getAudioUrl(asset.id);
+      if (!url) continue;
+
+      result.push({ clip, asset, url });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute the overall timeline end from all clips (audio-contributing or not).
+ */
+function getSequenceEndMs(project: Project): number {
+  let endMs = 0;
+  for (const track of project.sequence.tracks) {
+    for (const clip of track.clips) {
+      const clipEnd = clip.startMs + clip.durationMs;
+      if (clipEnd > endMs) endMs = clipEnd;
+    }
+  }
+  return endMs;
+}
+
+/**
+ * Evaluate volume keyframes for a clip and schedule gain automation.
+ *
+ * Samples keyframe values at 100 ms intervals and schedules
+ * linearRampToValueAtTime for smooth interpolation.
+ */
+function scheduleVolumeKeyframes(
+  gainNode: GainNode,
+  clip: Clip,
+  baseVolume: number,
+): void {
+  const volumeTrack = clip.keyframeTracks?.find(
+    (t: KeyframeTrack) => t.property === "volume",
+  );
+  if (!volumeTrack || volumeTrack.keyframes.length === 0) return;
+
+  const clipStartSec = clip.startMs / 1000;
+  const clipDurationMs = clip.durationMs;
+
+  // Sample at 100 ms intervals
+  const stepMs = 100;
+  for (let offsetMs = 0; offsetMs <= clipDurationMs; offsetMs += stepMs) {
+    const kfValue = evaluateKeyframeValue(volumeTrack, offsetMs);
+    if (kfValue !== undefined) {
+      const timeSec = clipStartSec + offsetMs / 1000;
+      const volume = kfValue * baseVolume;
+      if (offsetMs === 0) {
+        gainNode.gain.setValueAtTime(volume, timeSec);
+      } else {
+        gainNode.gain.linearRampToValueAtTime(volume, timeSec);
+      }
+    }
+  }
+}
+
+/**
+ * Simple linear keyframe evaluator (handles linear easing only for
+ * gain scheduling — good enough for OfflineAudioContext).
+ */
+function evaluateKeyframeValue(
+  track: KeyframeTrack,
+  timeMs: number,
+): number | undefined {
+  const kfs = track.keyframes;
+  if (kfs.length === 0) return undefined;
+
+  // Before first keyframe
+  if (timeMs <= kfs[0].timeMs) return kfs[0].value;
+
+  // After last keyframe
+  if (timeMs >= kfs[kfs.length - 1].timeMs) return kfs[kfs.length - 1].value;
+
+  // Find surrounding keyframes
+  for (let i = 0; i < kfs.length - 1; i++) {
+    const a = kfs[i];
+    const b = kfs[i + 1];
+    if (timeMs >= a.timeMs && timeMs <= b.timeMs) {
+      const t = (timeMs - a.timeMs) / (b.timeMs - a.timeMs);
+      return a.value + (b.value - a.value) * t;
+    }
+  }
+
+  return undefined;
+}
+
+// ── Main entry ──
+
+/**
+ * Mix all audio clips in the project into a single AudioBuffer using
+ * OfflineAudioContext. Returns null if there are no audio clips.
+ */
+export async function mixAudio(
+  options: AudioMixOptions,
+): Promise<AudioMixResult | null> {
+  const { project, getAudioUrl, onProgress } = options;
+  const sampleRate = options.sampleRate ?? 48_000;
+  const numberOfChannels = 2; // stereo
+
+  const audioClips = collectAudioClips(project, getAudioUrl);
+  if (audioClips.length === 0) return null;
+
+  const durationMs = getSequenceEndMs(project);
+  if (durationMs <= 0) return null;
+
+  const durationSec = durationMs / 1000;
+  const totalSamples = Math.ceil(durationSec * sampleRate);
+
+  const offlineCtx = new OfflineAudioContext(
+    numberOfChannels,
+    totalSamples,
+    sampleRate,
+  );
+
+  // Fetch and decode all audio files in parallel
+  const decoded: { info: AudioClipInfo; buffer: AudioBuffer }[] = [];
+  const fetchPromises = audioClips.map(async (info, index) => {
+    try {
+      const response = await fetch(info.url);
+      if (!response.ok) {
+        console.warn(
+          `[audio-mixer] Failed to fetch audio for asset ${info.asset.id}: ${response.status}`,
+        );
+        return;
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      const audioBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
+      decoded.push({ info, buffer: audioBuffer });
+    } catch (err) {
+      console.warn(
+        `[audio-mixer] Failed to decode audio for asset ${info.asset.id}:`,
+        err,
+      );
+    }
+    if (onProgress) {
+      onProgress(((index + 1) / audioClips.length) * 0.5); // first 50% = fetch/decode
+    }
+  });
+
+  await Promise.all(fetchPromises);
+
+  if (decoded.length === 0) return null;
+
+  // Schedule each decoded clip
+  for (const { info, buffer } of decoded) {
+    const { clip } = info;
+    const speed = clip.speed ?? 1;
+    const baseVolume = clip.volume ?? 1;
+
+    const sourceNode = offlineCtx.createBufferSource();
+    sourceNode.buffer = buffer;
+    sourceNode.playbackRate.value = speed;
+
+    const gainNode = offlineCtx.createGain();
+    gainNode.gain.value = baseVolume;
+
+    // Schedule volume keyframes if present
+    scheduleVolumeKeyframes(gainNode, clip, baseVolume);
+
+    sourceNode.connect(gainNode);
+    gainNode.connect(offlineCtx.destination);
+
+    const startTimeSec = clip.startMs / 1000;
+    const offsetSec = clip.inMs / 1000;
+    const playDurationSec = (clip.outMs - clip.inMs) / 1000 / speed;
+
+    sourceNode.start(startTimeSec, offsetSec, playDurationSec);
+  }
+
+  // Render
+  if (onProgress) onProgress(0.6);
+
+  const renderedBuffer = await offlineCtx.startRendering();
+
+  if (onProgress) onProgress(1);
+
+  return {
+    audioBuffer: renderedBuffer,
+    sampleRate,
+    durationMs,
+  };
+}

--- a/app/frontend/src/lib/canvas-export.ts
+++ b/app/frontend/src/lib/canvas-export.ts
@@ -6,8 +6,12 @@ import {
   BufferTarget,
   CanvasSource,
   canEncodeVideo,
+  canEncodeAudio,
+  AudioBufferSource,
   type VideoEncodingConfig,
+  type AudioEncodingConfig,
 } from "mediabunny";
+import { mixAudio, type AudioMixResult } from "./audio-mixer";
 
 // ── Types ──
 
@@ -26,6 +30,8 @@ export type CanvasExportOptions = {
     assetId: string,
     clipTimeMs: number,
   ) => Promise<CanvasImageSource | null>;
+  /** Resolve an asset ID to a fetchable audio URL, or null to skip. */
+  getAudioUrl?: (assetId: string) => string | null;
   /** Progress callback (0..1) */
   onProgress?: (progress: number) => void;
 };
@@ -89,6 +95,49 @@ function clipTimeForAsset(
   return 0;
 }
 
+// ── Audio helpers ──
+
+/**
+ * Pre-mix audio and determine encoding config.
+ * Returns the mixed audio and an AudioBufferSource ready to be added as a track,
+ * or null if no audio is available.
+ */
+async function prepareMixedAudio(
+  project: Project,
+  getAudioUrl?: (assetId: string) => string | null,
+): Promise<{ audioSource: AudioBufferSource; audioResult: AudioMixResult } | null> {
+  if (!getAudioUrl) return null;
+
+  let audioResult: AudioMixResult | null;
+  try {
+    audioResult = await mixAudio({ project, getAudioUrl });
+  } catch (err) {
+    console.warn("[canvas-export] Audio mixing failed, exporting video only:", err);
+    return null;
+  }
+  if (!audioResult) return null;
+
+  // Check AAC support, fall back to opus
+  let audioCodec: "aac" | "opus" = "aac";
+  const canAac = await canEncodeAudio("aac");
+  if (!canAac) {
+    const canOpus = await canEncodeAudio("opus");
+    if (!canOpus) {
+      console.warn("[canvas-export] No supported audio codec found, exporting video only");
+      return null;
+    }
+    audioCodec = "opus";
+  }
+
+  const audioConfig: AudioEncodingConfig = {
+    codec: audioCodec,
+    bitrate: 192_000,
+  };
+
+  const audioSource = new AudioBufferSource(audioConfig);
+  return { audioSource, audioResult };
+}
+
 // ── Main export function ──
 
 export async function exportWithCanvas(
@@ -97,6 +146,7 @@ export async function exportWithCanvas(
   const {
     project,
     getFrameSource,
+    getAudioUrl,
     onProgress,
   } = opts;
 
@@ -128,7 +178,10 @@ export async function exportWithCanvas(
   // 2. Create CanvasCompositor
   const compositor = new CanvasCompositor(canvas);
 
-  // 3. Determine video codec — try AVC first, fall back
+  // 3. Pre-mix audio (runs before video setup so track is added before start)
+  const audioPrep = await prepareMixedAudio(project, getAudioUrl);
+
+  // 4. Determine video codec — try AVC first, fall back
   let videoCodec: "avc" | "vp9" | "vp8" = "avc";
   const canAvc = await canEncodeVideo("avc", {
     width,
@@ -144,7 +197,7 @@ export async function exportWithCanvas(
     videoCodec = canVp9 ? "vp9" : "vp8";
   }
 
-  // 4. Configure encoding and muxing
+  // 5. Configure encoding and muxing
   const encodingConfig: VideoEncodingConfig = {
     codec: videoCodec,
     bitrate: videoBitrate,
@@ -161,6 +214,12 @@ export async function exportWithCanvas(
   });
 
   output.addVideoTrack(canvasSource);
+
+  // Add audio track before starting (required by mediabunny)
+  if (audioPrep) {
+    output.addAudioTrack(audioPrep.audioSource);
+  }
+
   await output.start();
 
   // 5. Render each frame
@@ -202,10 +261,16 @@ export async function exportWithCanvas(
     compositor.dispose();
   }
 
-  // 6. Finalize output
+  // 6. Feed mixed audio into the audio source (after video frames are done)
+  if (audioPrep) {
+    await audioPrep.audioSource.add(audioPrep.audioResult.audioBuffer);
+    audioPrep.audioSource.close();
+  }
+
+  // 7. Finalize output
   await output.finalize();
 
-  // 7. Build result blob
+  // 8. Build result blob
   const buffer = target.buffer;
   if (!buffer) {
     throw new Error("Export failed: no output buffer produced");
@@ -245,7 +310,7 @@ export function isWorkerExportSupported(): boolean {
 export async function exportWithWorker(
   opts: CanvasExportOptions,
 ): Promise<CanvasExportResult> {
-  const { project, getFrameSource, onProgress } = opts;
+  const { project, getFrameSource, getAudioUrl, onProgress } = opts;
 
   const width = opts.width ?? project.settings.canvasWidth;
   const height = opts.height ?? project.settings.canvasHeight;
@@ -260,11 +325,14 @@ export async function exportWithWorker(
   const totalFrames = Math.ceil((endMs / 1000) * fps);
   const frameDurationSec = 1 / fps;
 
-  // 1. Create canvas for rendering on main thread
+  // 1. Pre-mix audio on main thread (OfflineAudioContext not available in workers)
+  const audioPrep = await prepareMixedAudio(project, getAudioUrl);
+
+  // 2. Create canvas for rendering on main thread
   const canvas = new OffscreenCanvas(width, height);
   const compositor = new CanvasCompositor(canvas);
 
-  // 2. Create and initialize the worker
+  // 3. Create and initialize the worker
   const worker = new Worker(
     new URL("./export-worker.ts", import.meta.url),
     { type: "module" },
@@ -284,9 +352,23 @@ export async function exportWithWorker(
     worker.addEventListener("message", onMessage);
   });
 
+  // Determine audio codec config to pass to worker (if audio is available)
+  let audioCodecForWorker: "aac" | "opus" | null = null;
+  if (audioPrep) {
+    const canAac = await canEncodeAudio("aac");
+    audioCodecForWorker = canAac ? "aac" : "opus";
+  }
+
   worker.postMessage({
     type: "init",
-    data: { width, height, fps, videoBitrate },
+    data: {
+      width,
+      height,
+      fps,
+      videoBitrate,
+      audioCodec: audioCodecForWorker,
+      audioBitrate: audioCodecForWorker ? 192_000 : undefined,
+    },
   });
 
   await workerReady;
@@ -350,7 +432,33 @@ export async function exportWithWorker(
     compositor.dispose();
   }
 
-  // 4. Flush and wait for result
+  // 4. Send mixed audio data to worker (AudioBuffer is not transferable,
+  //    so we extract Float32Array channel data and transfer those)
+  if (audioPrep) {
+    const { audioBuffer, sampleRate } = audioPrep.audioResult;
+    const channelData: Float32Array[] = [];
+    const transferables: ArrayBuffer[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      // Copy channel data (getChannelData returns a reference to internal buffer)
+      const data = new Float32Array(audioBuffer.getChannelData(ch));
+      channelData.push(data);
+      transferables.push(data.buffer);
+    }
+    worker.postMessage(
+      {
+        type: "audio",
+        data: {
+          channelData,
+          sampleRate,
+          length: audioBuffer.length,
+          numberOfChannels: audioBuffer.numberOfChannels,
+        },
+      },
+      transferables,
+    );
+  }
+
+  // 5. Flush and wait for result
   const result = await new Promise<Blob>((resolve, reject) => {
     const onMessage = (e: MessageEvent) => {
       if (e.data.type === "done") {
@@ -365,7 +473,7 @@ export async function exportWithWorker(
     worker.postMessage({ type: "flush" });
   });
 
-  // 5. Terminate worker
+  // 6. Terminate worker
   worker.terminate();
 
   return {

--- a/app/frontend/src/lib/export-worker.ts
+++ b/app/frontend/src/lib/export-worker.ts
@@ -4,9 +4,11 @@
  *
  * Protocol:
  *   Main -> Worker:
- *     { type: "init", data: { width, height, fps, videoBitrate } }
+ *     { type: "init", data: { width, height, fps, videoBitrate, audioCodec?, audioBitrate? } }
  *     { type: "frame", data: { bitmap: ImageBitmap, timestamp: number, duration: number, progress: number } }
  *       (bitmap is transferred, not copied)
+ *     { type: "audio", data: { channelData: Float32Array[], sampleRate: number, length: number, numberOfChannels: number } }
+ *       (channelData buffers are transferred)
  *     { type: "flush" }
  *
  *   Worker -> Main:
@@ -22,11 +24,14 @@ import {
   BufferTarget,
   VideoSampleSource,
   VideoSample,
+  AudioBufferSource,
   canEncodeVideo,
   type VideoEncodingConfig,
+  type AudioEncodingConfig,
 } from "mediabunny";
 
 let videoSource: VideoSampleSource | null = null;
+let audioSource: AudioBufferSource | null = null;
 let output: Output | null = null;
 let target: BufferTarget | null = null;
 
@@ -35,15 +40,17 @@ self.onmessage = async (e: MessageEvent) => {
 
   try {
     if (type === "init") {
-      const { width, height, fps: _fps, videoBitrate } = data as {
+      const { width, height, fps: _fps, videoBitrate, audioCodec, audioBitrate } = data as {
         width: number;
         height: number;
         fps: number;
         videoBitrate: number;
+        audioCodec?: "aac" | "opus" | null;
+        audioBitrate?: number;
       };
 
       // Determine video codec — try AVC first, fall back
-      let videoCodec: "avc" | "vp9" | "vp8" = "avc";
+      let videoCodecChoice: "avc" | "vp9" | "vp8" = "avc";
       const canAvc = await canEncodeVideo("avc", {
         width,
         height,
@@ -55,17 +62,26 @@ self.onmessage = async (e: MessageEvent) => {
           height,
           bitrate: videoBitrate,
         });
-        videoCodec = canVp9 ? "vp9" : "vp8";
+        videoCodecChoice = canVp9 ? "vp9" : "vp8";
       }
 
       const encodingConfig: VideoEncodingConfig = {
-        codec: videoCodec,
+        codec: videoCodecChoice,
         bitrate: videoBitrate,
         keyFrameInterval: 2,
         hardwareAcceleration: "no-preference",
       };
 
       videoSource = new VideoSampleSource(encodingConfig);
+
+      // Set up audio source if audio codec was provided
+      if (audioCodec) {
+        const audioConfig: AudioEncodingConfig = {
+          codec: audioCodec,
+          bitrate: audioBitrate ?? 192_000,
+        };
+        audioSource = new AudioBufferSource(audioConfig);
+      }
 
       target = new BufferTarget();
       output = new Output({
@@ -74,6 +90,9 @@ self.onmessage = async (e: MessageEvent) => {
       });
 
       output.addVideoTrack(videoSource);
+      if (audioSource) {
+        output.addAudioTrack(audioSource);
+      }
       await output.start();
 
       self.postMessage({ type: "ready" });
@@ -106,6 +125,32 @@ self.onmessage = async (e: MessageEvent) => {
       self.postMessage({ type: "progress", value: progress });
     }
 
+    if (type === "audio") {
+      if (!audioSource) {
+        throw new Error("Audio source not initialized");
+      }
+
+      const { channelData, sampleRate, length, numberOfChannels } = data as {
+        channelData: Float32Array[];
+        sampleRate: number;
+        length: number;
+        numberOfChannels: number;
+      };
+
+      // Reconstruct AudioBuffer from transferred Float32Array channels
+      const audioBuffer = new AudioBuffer({
+        length,
+        numberOfChannels,
+        sampleRate,
+      });
+      for (let ch = 0; ch < numberOfChannels; ch++) {
+        audioBuffer.copyToChannel(channelData[ch], ch);
+      }
+
+      await audioSource.add(audioBuffer);
+      audioSource.close();
+    }
+
     if (type === "flush") {
       if (!output || !target) {
         throw new Error("Worker not initialized");
@@ -123,6 +168,7 @@ self.onmessage = async (e: MessageEvent) => {
 
       // Clean up
       videoSource = null;
+      audioSource = null;
       output = null;
       target = null;
     }


### PR DESCRIPTION
## Summary
- New `audio-mixer.ts` module using `OfflineAudioContext` to mix audio clips offline with timeline positioning, speed, volume, and keyframe automation
- Integrate audio into both `exportWithCanvas` and `exportWithWorker` paths via mediabunny's `AudioBufferSource` (AAC with opus fallback)
- Worker receives audio as transferred Float32Array channels, reconstructs AudioBuffer for encoding
- `CanvasExportPanel` now provides `getAudioUrl` callback and description updated to reflect audio support

Closes #121

## Test plan
- [x] `bun run test` — all 1069 tests pass
- [x] oxlint clean on all changed files
- [ ] Manual: export a project with audio clips, verify MP4 contains audio track

🤖 Generated with [Claude Code](https://claude.com/claude-code)