### PR TITLE
Replace ffprobe with mediabunny for media metadata

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -7,7 +7,8 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@video/shared": "workspace:*",
     "hono": "^4",
-    "@video/shared": "workspace:*"
+    "mediabunny": "^1.40.1"
   }
 }

--- a/app/backend/src/pipeline/tools/ffmpeg.ts
+++ b/app/backend/src/pipeline/tools/ffmpeg.ts
@@ -1,4 +1,20 @@
 import type { FfmpegTool, ProbeResult } from "../types";
+import {
+  Input,
+  FilePathSource,
+  MP4,
+  QTFF,
+  MATROSKA,
+  WEBM,
+  MP3,
+  WAVE,
+  OGG,
+  FLAC,
+  ADTS,
+  MPEG_TS,
+} from "mediabunny";
+
+const MEDIA_FORMATS = [MP4, QTFF, MATROSKA, WEBM, MP3, WAVE, OGG, FLAC, ADTS, MPEG_TS];
 
 async function spawn(
   cmd: string,
@@ -70,40 +86,39 @@ async function probeJson(inputPath: string): Promise<any> {
   throw lastError;
 }
 
-export const ffmpegTool: FfmpegTool = {
-  async checkInstalled() {
-    const [ffmpeg, ffprobe] = await Promise.all([
-      spawn("ffmpeg", ["-version"]),
-      spawn("ffprobe", ["-version"]),
-    ]);
-    if (ffmpeg.exitCode !== 0) throw new Error("ffmpeg not found");
-    if (ffprobe.exitCode !== 0) throw new Error("ffprobe not found");
-  },
+/**
+ * Probe a media file using mediabunny (handles video/audio container formats).
+ */
+async function probeWithMediabunny(inputPath: string): Promise<ProbeResult> {
+  const source = new FilePathSource(inputPath);
+  const input = new Input({ formats: MEDIA_FORMATS, source });
 
-  async probe(inputPath) {
-    const data = await probeJson(inputPath);
-    const videoStream = data.streams?.find(
-      (s: { codec_type: string }) => s.codec_type === "video",
-    );
-    const audioStream = data.streams?.find(
-      (s: { codec_type: string }) => s.codec_type === "audio",
-    );
+  try {
+    const videoTrack = await input.getPrimaryVideoTrack();
+    const audioTrack = await input.getPrimaryAudioTrack();
 
-    const width = videoStream?.width ?? 0;
-    const height = videoStream?.height ?? 0;
-    const rotation = videoStream?.tags?.rotate
-      ? parseInt(videoStream.tags.rotate, 10)
-      : undefined;
-    const durationSec =
-      videoStream?.duration ?? data.format?.duration;
-    const durationMs = durationSec
-      ? Math.round(parseFloat(durationSec) * 1000)
-      : undefined;
-    const codec = videoStream?.codec_name ?? audioStream?.codec_name ?? "unknown";
-    const colorSpace = videoStream?.color_space ?? undefined;
-    const isHdr =
-      videoStream?.color_transfer === "smpte2084" ||
-      videoStream?.color_transfer === "arib-std-b67";
+    let width = 0;
+    let height = 0;
+    let rotation: number | undefined;
+    let codec = "unknown";
+    let colorSpace: string | undefined;
+    let isHdr = false;
+
+    if (videoTrack) {
+      width = videoTrack.codedWidth;
+      height = videoTrack.codedHeight;
+      rotation = videoTrack.rotation || undefined;
+      codec = videoTrack.codec ?? "unknown";
+
+      const cs = await videoTrack.getColorSpace();
+      if (cs.matrix) colorSpace = cs.matrix;
+      isHdr = await videoTrack.hasHighDynamicRange();
+    } else if (audioTrack) {
+      codec = audioTrack.codec ?? "unknown";
+    }
+
+    const durationSec = await input.computeDuration();
+    const durationMs = durationSec > 0 ? Math.round(durationSec * 1000) : undefined;
 
     return {
       width,
@@ -112,9 +127,103 @@ export const ffmpegTool: FfmpegTool = {
       codec,
       rotation,
       colorSpace,
-      hasAudio: !!audioStream,
+      hasAudio: !!audioTrack,
       isHdr,
-    } satisfies ProbeResult;
+    };
+  } finally {
+    input.dispose();
+  }
+}
+
+/**
+ * Probe an image file by reading its header bytes to extract dimensions.
+ * Supports JPEG, PNG, GIF, BMP, and WebP.
+ */
+async function probeImageFile(inputPath: string): Promise<ProbeResult> {
+  const file = Bun.file(inputPath);
+  // Read first 32 bytes for header inspection
+  const headerBuf = await file.slice(0, 32).arrayBuffer();
+  const header = new Uint8Array(headerBuf);
+
+  let width = 0;
+  let height = 0;
+  let codec = "unknown";
+
+  // PNG: 8-byte signature, then IHDR chunk at offset 16 (width) and 20 (height)
+  if (header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4E && header[3] === 0x47) {
+    codec = "png";
+    const view = new DataView(headerBuf);
+    width = view.getUint32(16);
+    height = view.getUint32(20);
+  }
+  // GIF: "GIF8" signature, width/height at offset 6/8 (little-endian 16-bit)
+  else if (header[0] === 0x47 && header[1] === 0x49 && header[2] === 0x46) {
+    codec = "gif";
+    const view = new DataView(headerBuf);
+    width = view.getUint16(6, true);
+    height = view.getUint16(8, true);
+  }
+  // BMP: "BM" signature, width/height at offset 18/22 (little-endian 32-bit)
+  else if (header[0] === 0x42 && header[1] === 0x4D) {
+    codec = "bmp";
+    const view = new DataView(headerBuf);
+    width = view.getInt32(18, true);
+    height = Math.abs(view.getInt32(22, true));
+  }
+  // WebP: "RIFF....WEBP" + VP8 chunk
+  else if (header[0] === 0x52 && header[1] === 0x49 && header[2] === 0x46 && header[3] === 0x46 &&
+           header[8] === 0x57 && header[9] === 0x45 && header[10] === 0x42 && header[11] === 0x50) {
+    codec = "webp";
+    // VP8 lossy: chunk at offset 12 = "VP8 ", dimensions at offset 26/28
+    if (header[12] === 0x56 && header[13] === 0x50 && header[14] === 0x38 && header[15] === 0x20) {
+      const view = new DataView(headerBuf);
+      width = view.getUint16(26, true) & 0x3FFF;
+      height = view.getUint16(28, true) & 0x3FFF;
+    }
+  }
+  // JPEG: Read SOF marker for dimensions (needs more bytes)
+  else if (header[0] === 0xFF && header[1] === 0xD8) {
+    codec = "jpeg";
+    // Read up to 64KB for JPEG SOF marker search
+    const jpegBuf = await file.slice(0, 65536).arrayBuffer();
+    const jpegBytes = new Uint8Array(jpegBuf);
+    const jpegView = new DataView(jpegBuf);
+    let offset = 2;
+    while (offset < jpegBytes.length - 8) {
+      if (jpegBytes[offset] !== 0xFF) break;
+      const marker = jpegBytes[offset + 1];
+      // SOF markers: 0xC0-0xCF except 0xC4 (DHT) and 0xCC (DAC)
+      if (marker >= 0xC0 && marker <= 0xCF && marker !== 0xC4 && marker !== 0xCC) {
+        height = jpegView.getUint16(offset + 5);
+        width = jpegView.getUint16(offset + 7);
+        break;
+      }
+      const segLen = jpegView.getUint16(offset + 2);
+      offset += 2 + segLen;
+    }
+  }
+
+  return {
+    width,
+    height,
+    codec,
+  };
+}
+
+export const ffmpegTool: FfmpegTool = {
+  async checkInstalled() {
+    const result = await spawn("ffmpeg", ["-version"]);
+    if (result.exitCode !== 0) throw new Error("ffmpeg not found");
+  },
+
+  async probe(inputPath) {
+    // Try mediabunny first (handles video/audio container formats)
+    try {
+      return await probeWithMediabunny(inputPath);
+    } catch {
+      // Fallback for image files — mediabunny doesn't support image formats
+      return probeImageFile(inputPath);
+    }
   },
 
   async generateThumbnail(inputPath, outputPath) {

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "dependencies": {
         "@video/shared": "workspace:*",
         "hono": "^4",
+        "mediabunny": "^1.40.1",
       },
     },
     "app/frontend": {


### PR DESCRIPTION
## Summary
- Replace `ffprobe` CLI dependency with mediabunny's `Input` API for probing video/audio container formats
- Add lightweight image header parsing for JPEG, PNG, GIF, BMP, WebP dimensions
- Remove `ffprobe` from `checkInstalled()` — only `ffmpeg` is still needed (for thumbnail/proxy generation until #123/#124)
- Add `mediabunny` as backend dependency

Closes #122

## Test plan
- [x] `bun run test` — all 1069 tests pass
- [x] Existing `ffmpeg.test.ts` probe tests pass (video and image metadata)
- [x] oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)