### PR TITLE
Dedupe plugin registration to prevent double-register (fixes #140)

### DIFF
--- a/app/frontend/.storybook/vitest.setup.ts
+++ b/app/frontend/.storybook/vitest.setup.ts
@@ -1,10 +1,9 @@
 import { beforeAll } from "vitest";
 import { setProjectAnnotations } from "@storybook/react-vite";
+// Importing ./preview has a module side effect of calling `loadPlugins([builtinPlugin])`,
+// so do NOT also call `loadPlugins` here — that would register every plugin twice.
+// See issue #140.
 import * as previewAnnotations from "./preview";
-import { loadPlugins } from "../src/lib/plugin-loader";
-import { builtinPlugin } from "../src/lib/builtin-plugin";
-
-loadPlugins([builtinPlugin]);
 
 const annotations = setProjectAnnotations([previewAnnotations]);
 

--- a/app/frontend/src/lib/inspector-editor-registry.test.ts
+++ b/app/frontend/src/lib/inspector-editor-registry.test.ts
@@ -89,6 +89,67 @@ describe("InspectorEditorRegistry", () => {
       expect(registry.getEditorsFor(makeCtx())).toEqual([]);
     });
 
+    test("register is idempotent by id (same id registered twice yields one editor)", () => {
+      const plugin: InspectorEditorPlugin = {
+        id: "dup",
+        label: "Dup",
+        order: 1,
+        canHandle: () => true,
+        Component: dummyComponent,
+      };
+      registry.register(plugin);
+      registry.register(plugin);
+      const editors = registry.getEditorsFor(makeCtx());
+      expect(editors.filter((e) => e.id === "dup").length).toBe(1);
+      expect(editors.length).toBe(1);
+    });
+
+    test("re-registering with updated fields replaces the original (latest wins)", () => {
+      registry.register({
+        id: "swap",
+        label: "Original",
+        order: 1,
+        canHandle: () => true,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "swap",
+        label: "Updated",
+        order: 1,
+        canHandle: () => true,
+        Component: dummyComponent,
+      });
+      const editors = registry.getEditorsFor(makeCtx());
+      expect(editors.length).toBe(1);
+      expect(editors[0].label).toBe("Updated");
+    });
+
+    test("registering different ids still accumulates all editors", () => {
+      registry.register({
+        id: "a",
+        label: "A",
+        order: 1,
+        canHandle: () => true,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "b",
+        label: "B",
+        order: 2,
+        canHandle: () => true,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "c",
+        label: "C",
+        order: 3,
+        canHandle: () => true,
+        Component: dummyComponent,
+      });
+      const editors = registry.getEditorsFor(makeCtx());
+      expect(editors.map((e) => e.id)).toEqual(["a", "b", "c"]);
+    });
+
     test("canHandle receives correct context", () => {
       const calls: InspectorEditorContext[] = [];
       registry.register({

--- a/app/frontend/src/lib/inspector-editor-registry.ts
+++ b/app/frontend/src/lib/inspector-editor-registry.ts
@@ -21,6 +21,15 @@ export class InspectorEditorRegistry {
   private plugins: InspectorEditorPlugin[] = [];
 
   register(plugin: InspectorEditorPlugin): void {
+    // Idempotent by id: if a plugin with the same id is already registered,
+    // replace it (latest wins). This matches Map.set semantics used by other
+    // registries and prevents duplicate entries when `loadPlugins` runs more
+    // than once (e.g. module side effect + explicit call in a test setup).
+    const existing = this.plugins.findIndex((p) => p.id === plugin.id);
+    if (existing >= 0) {
+      this.plugins[existing] = plugin;
+      return;
+    }
     this.plugins.push(plugin);
   }
 

--- a/app/frontend/src/lib/preview-renderer-registry.test.ts
+++ b/app/frontend/src/lib/preview-renderer-registry.test.ts
@@ -75,6 +75,61 @@ describe("PreviewRendererRegistry", () => {
       expect(registry.getTickStrategy("nonexistent")).toBeUndefined();
     });
 
+    test("register is idempotent by id (same id registered twice yields one entry)", () => {
+      const renderer: PreviewLayerRenderer = {
+        id: "dup",
+        zOrder: 10,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      };
+      registry.register(renderer);
+      registry.register(renderer);
+      const all = registry.all();
+      expect(all.filter((r) => r.id === "dup").length).toBe(1);
+      expect(all.length).toBe(1);
+    });
+
+    test("re-registering with updated fields replaces the original (latest wins)", () => {
+      registry.register({
+        id: "swap",
+        zOrder: 1,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "swap",
+        zOrder: 99,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      });
+      const all = registry.all();
+      expect(all.length).toBe(1);
+      expect(all[0].zOrder).toBe(99);
+    });
+
+    test("registering different ids still accumulates all entries", () => {
+      registry.register({
+        id: "a",
+        zOrder: 1,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "b",
+        zOrder: 2,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      });
+      registry.register({
+        id: "c",
+        zOrder: 3,
+        findActiveContent: () => null,
+        Component: dummyComponent,
+      });
+      const all = registry.all();
+      expect(all.map((r) => r.id).sort()).toEqual(["a", "b", "c"]);
+    });
+
     test("all returns a copy of renderers array", () => {
       registry.register({
         id: "r1",

--- a/app/frontend/src/lib/preview-renderer-registry.ts
+++ b/app/frontend/src/lib/preview-renderer-registry.ts
@@ -54,6 +54,15 @@ export class PreviewRendererRegistry {
   private tickStrategies = new Map<string, PlaybackTickStrategy>();
 
   register(renderer: PreviewLayerRenderer): void {
+    // Idempotent by id: if a renderer with the same id is already registered,
+    // replace it (latest wins). This matches Map.set semantics used by other
+    // registries and prevents duplicate entries when `loadPlugins` runs more
+    // than once (e.g. module side effect + explicit call in a test setup).
+    const existing = this.renderers.findIndex((r) => r.id === renderer.id);
+    if (existing >= 0) {
+      this.renderers[existing] = renderer;
+      return;
+    }
     this.renderers.push(renderer);
   }
 


### PR DESCRIPTION
## Summary
- Makes `previewRendererRegistry.register` and `inspectorEditorRegistry.register` idempotent by `id` (latest-wins)
- Removes the now-redundant explicit `loadPlugins` call from `.storybook/vitest.setup.ts` (the `import "./preview"` line already triggers it as a side effect since #139)
- Adds 6 unit tests covering the dedupe behavior

Fixes #140.

## Background
After #139 added `loadPlugins([builtinPlugin])` to `.storybook/preview.ts`, the addon-vitest test path registered plugins twice: once via the `import "./preview"` side effect in `vitest.setup.ts:3`, and again via the explicit `loadPlugins([builtinPlugin])` at line 7. The array-based registries (`PreviewRendererRegistry`, `InspectorEditorRegistry`) used `Array.push` so they accumulated duplicate entries. Tests still passed because downstream consumers were deterministic, but this was a latent hazard: any future `React.key` keyed on renderer identity, lifecycle hook, or "exactly one renderer per id" assertion would misbehave.

## Why combine A + B
- **Option B (idempotent register)** is defense-in-depth — even if a future contributor accidentally calls `loadPlugins` twice from a new entry point, the registries will no longer duplicate.
- **Option A (remove dead call)** is the targeted cleanup — dead code shouldn't live on.

Latest-wins semantics match the existing Map-based registries (`clipKindRegistry`, `assetKindRegistry`, `compositeStrategyRegistry`, `transitionPreviewRegistry`) which all use `Map.set`. This PR brings the two array-based registries into line with that contract.

## Changes
- `app/frontend/src/lib/preview-renderer-registry.ts` — `register` dedupes by `id`, replacing in place to preserve insertion order
- `app/frontend/src/lib/inspector-editor-registry.ts` — same pattern for `plugins` array
- `app/frontend/.storybook/vitest.setup.ts` — remove redundant `loadPlugins`/`builtinPlugin` imports and explicit call; add comment referencing #140 to prevent re-addition
- `app/frontend/src/lib/preview-renderer-registry.test.ts` — 3 new tests
- `app/frontend/src/lib/inspector-editor-registry.test.ts` — 3 new tests

### New tests cover
1. Registering same id twice → \`all()\` / \`getEditorsFor()\` returns 1 entry
2. Re-register with updated fields → latest wins (replaced entry visible)
3. Distinct ids → all accumulated correctly

## Verification
- \`bun run test\` → **793 pass / 0 fail** (787 baseline + 6 new)
- \`bun run tools/storybook-verify/verify-all.ts\` → **ok=211 error=0**
- \`xvfb-run bun run test:browser\` → **208 pass / 2 fail / 1 skip** (matches baseline; the 2 failures are pre-existing unrelated InspectorPanel tests)

## Test plan
- [x] Unit tests for idempotent register added + passing
- [x] Full test suite 793/793
- [x] Storybook verify-all.ts 211/211
- [x] Browser test baseline unchanged
- [x] Pre-merge review done in separate subagent per CLAUDE.md — APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)