### PR TITLE
Document Storybook setup, MSW, and verify-all tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,92 @@ Preview regression tests capture browser-rendered preview frames via Playwright 
 - Add entry to `EXPORT_TESTS` in `tools/feature-catalog/index.ts`
 - Verify frames visually in feature catalog before committing
 
+## Storybook
+
+Storybook acts as both the component catalog and an in-browser test runner (via `@storybook/addon-vitest`). It is also the primary place to exercise UI states that are hard to reach in the full app.
+
+### Structure & stack
+
+- Storybook 10.2.17 on `@storybook/react-vite`
+- Config at `app/frontend/.storybook/` (`main.ts`, `preview.ts`, `manager.ts`, `vitest.setup.ts`)
+- Story files are colocated with components as `app/frontend/src/**/*.stories.tsx`
+- Currently 20+ story files, 200+ story entries
+
+### Plugin system inside Storybook
+
+`.storybook/preview.ts` must call `loadPlugins([builtinPlugin])` at module top level (before `definePreview`). Without it, `previewRendererRegistry` and `inspectorEditorRegistry` are empty, so components that rely on dynamic renderer discovery — most importantly `PreviewPlayer` — render an empty state in stories.
+
+The same `loadPlugins([builtinPlugin])` call also exists in:
+
+- `app/frontend/src/main.tsx` (production entry)
+- `app/frontend/.storybook/vitest.setup.ts` (addon-vitest test runner entry)
+
+Registry `register` methods are idempotent and dedup by `id` with latest-wins semantics, so importing the builtin plugin from multiple entry points is safe.
+
+### Mocking with MSW
+
+All network mocking is done through [MSW](https://mswjs.io/) via `msw-storybook-addon`. **Do not use `sb.mock` or per-story `queryClient.setQueryData()` to fake API responses** — the latter conflicts with MSW because React Query will refetch and overwrite the seeded cache. (Providing a `QueryClientProvider` at the meta decorator level is still fine — components need a client in context.)
+
+- Global handlers: `app/frontend/src/mocks/handlers.ts`. Defaults return empty lists / echo-id objects so any data-fetching story avoids `Query data cannot be undefined` errors.
+- Per-story override: set `parameters.msw.handlers`. Canonical pattern:
+
+```tsx
+import { http, HttpResponse } from "msw";
+import { mockProject } from "../stories/fixtures";
+
+export const WithProjects = meta.story({
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/projects", () =>
+          HttpResponse.json({ projects: [mockProject()] }),
+        ),
+      ],
+    },
+  },
+});
+```
+
+- addon-vitest browser tests (`bun run test:browser`) automatically pick up the same MSW handlers — no extra setup required.
+- Reference examples of per-story MSW overrides: `HomePage.stories.tsx`, `EditorPage.stories.tsx`, `JobLogPage.stories.tsx`, `AssetThumbnail.stories.tsx`.
+
+### Writing a new story
+
+1. Create `<Component>.stories.tsx` next to the component.
+2. Use the Storybook 10.x `preview.meta(...).story(...)` pattern — import `preview` from `../../.storybook/preview` (adjust depth).
+3. If the component fetches data, either rely on the default handlers in `src/mocks/handlers.ts` or add per-story overrides via `parameters.msw.handlers`.
+4. For components that need a specific project/asset shape, pass fixtures from `app/frontend/src/stories/fixtures.ts` (`mockProject`, `mockClip`, `mockAsset`, `mockJob`, `projectWithClips`, `projectWithTextOverlay`, etc.) via `args`.
+5. Add interaction tests as `StoryName.test("...", async ({ canvas }) => { ... })` blocks — they run in Playwright via addon-vitest.
+
+### Verification tooling
+
+`tools/storybook-verify/verify-all.ts` is a Playwright script that iterates every story via `index.json`, opens it in `iframe.html`, and collects:
+
+- `pageerror` events
+- `console.error` messages
+- Storybook error-overlay text
+- `#storybook-root` HTML size (to flag accidentally empty stories)
+- Full-page PNG screenshot per story
+
+Output goes to `tools/storybook-verify/report.json` and `tools/storybook-verify/screenshots/*.png` — both are gitignored.
+
+**Limitation:** it only catches JS errors and empty roots, not visual regressions. For visual issues you must read the screenshots yourself. If a whole category of stories all show unexpected empty states, suspect a loader/registry issue (e.g. a missing `loadPlugins` call).
+
+### Reference commands
+
+| Command | Purpose |
+|---------|---------|
+| `devcontainer exec --workspace-folder . bash -c "cd /workspace/app/frontend && bun run storybook"` | Start Storybook on port 6006 |
+| `devcontainer exec --workspace-folder . bash -c "cd /workspace && bun run tools/storybook-verify/verify-all.ts"` | Run bulk verify over all stories (requires Storybook running) |
+| `devcontainer exec --workspace-folder . bash -c "cd /workspace && bun run tools/storybook-verify/verify-all.ts --limit 5"` | Smoke-run first 5 stories only |
+| `devcontainer exec --workspace-folder . bash -c "cd /workspace/app/frontend && xvfb-run bun run test:browser"` | Run addon-vitest browser tests (interaction tests) |
+
+### Related context
+
+- #137 — MSW adoption as the Storybook mocking layer (replaces `sb.mock`)
+- #139 — `loadPlugins([builtinPlugin])` in `.storybook/preview.ts` (fixed empty `PreviewPlayer` in stories)
+- #140 — Registry `register` dedup (idempotent by id, latest-wins)
+
 ## PR merge checklist
 
 Before merging any PR, always:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,66 @@ cd app/frontend && bun run build
 
 ### Storybook
 
-Storybook provides an interactive component catalog and test runner for all UI components. Opens at http://localhost:6006. Test results are visible in the Interactions panel for each story.
+Storybook is used as both an interactive component catalog and an in-browser test runner for all UI components. Interaction tests are written as `.test()` calls on stories and run in a real Chromium via `@storybook/addon-vitest` + Playwright — results show up in the Interactions panel of each story.
 
-Component tests are written as `.test()` calls in `*.stories.tsx` files and run in a real browser via Playwright.
+Start it from `app/frontend/`:
+
+```sh
+cd app/frontend && bun run storybook
+```
+
+Opens at http://localhost:6006.
+
+#### Story structure
+
+Story files live next to the component they document as `*.stories.tsx`. They use the Storybook 10.x `meta.story(...)` pattern:
+
+```tsx
+import preview from "../../.storybook/preview";
+import { MyComponent } from "./MyComponent";
+
+const meta = preview.meta({
+  title: "Components/MyComponent",
+  component: MyComponent,
+});
+
+export const Default = meta.story({});
+
+Default.test("renders label", async ({ canvas }) => {
+  await canvas.findByText("hello");
+});
+```
+
+#### Mocking API calls (MSW)
+
+All network mocking goes through [MSW](https://mswjs.io/) via `msw-storybook-addon`. Default handlers live in `app/frontend/src/mocks/handlers.ts` and return empty lists / echo-id responses — enough that any data-fetching story renders its loaded state instead of an error from React Query.
+
+To override for a specific story, set `parameters.msw.handlers`:
+
+```tsx
+import { http, HttpResponse } from "msw";
+import { mockProject } from "../stories/fixtures";
+
+export const WithProjects = meta.story({
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/projects", () =>
+          HttpResponse.json({ projects: [mockProject()] }),
+        ),
+      ],
+    },
+  },
+});
+```
+
+The same MSW handlers are automatically picked up by addon-vitest browser tests — no extra setup needed.
+
+#### Bulk verification
+
+`tools/storybook-verify/verify-all.ts` is a Playwright-based script that walks every story in a running Storybook, captures page errors / console errors / error-overlay text, and writes full-page screenshots plus a `report.json` under `tools/storybook-verify/` (screenshots and report are gitignored). Run it after any change that could touch many stories at once.
+
+See [CLAUDE.md](./CLAUDE.md#storybook) for the detailed workflow, fixtures, and devcontainer-wrapped command invocations.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
Adds documentation for the Storybook machinery introduced by PRs #138, #139, #141 — none of which was reflected in README.md or CLAUDE.md until now.

## What's new in the docs

### README.md (Storybook section expanded)
- Role of Storybook in this repo (component catalog + interaction tests)
- How to start (`bun run storybook`)
- Story file layout and `meta.story()` pattern
- **MSW mocking strategy** — default handlers + per-story override with a concrete code example
- Mention of `tools/storybook-verify/verify-all.ts`
- Link back to CLAUDE.md for deeper workflow

### CLAUDE.md (new `## Storybook` section)
- Stack: Storybook 10.2.17 + react-vite, file layout, story count
- **Plugin system**: why `loadPlugins([builtinPlugin])` must be in `.storybook/preview.ts`, and the idempotent register contract
- **Mocking with MSW**: anti-pattern warning about `queryClient.setQueryData` (conflicts with refetch), global handler location, canonical per-story override pattern, addon-vitest compatibility note
- **Writing a new story**: 5-step checklist with fixture references
- **Verification tooling**: what `verify-all.ts` collects, output locations (gitignored), the "JS errors only" limitation
- **Reference commands** table (full `devcontainer exec` form)
- Links to #137, #139, #140 for context

## Structure note
Pre-merge review caught that the initial placement of `## Storybook` in CLAUDE.md split the `## Regression testing workflow` section in half, orphaning `### Adding new export regression test cases`. Fixed by moving `## Storybook` to AFTER that subsection. Content unchanged.

## Test plan
- [x] Cross-checked every file path, command, and API shape against the actual codebase (subagent review)
- [x] Verified all GitHub references (#137 closed by #138, #139 merged, #140 closed by #141) via `gh`
- [x] CLAUDE.md heading hierarchy clean (no orphans)
- [x] No code modified
- [x] Implementation and review done in separate subagents per CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)